### PR TITLE
fix(southland): invercargill 2022 0.1m coverage name differes to LDS

### DIFF
--- a/stac/southland/invercargill_2022_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.1m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GFW60E6AJ9C95YFQ2ZJ4SVZ9",
-  "title": "Invercargill 0.1m Rural Aerial Photos (2022)",
+  "title": "Invercargill 0.1m Urban Aerial Photos (2022)",
   "description": "Invercargill 0.1m Rural Aerial Photos",
   "license": "CC-BY-4.0",
   "links": [

--- a/stac/southland/invercargill_2022_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.1m/rgb/2193/collection.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "01GFW60E6AJ9C95YFQ2ZJ4SVZ9",
   "title": "Invercargill 0.1m Urban Aerial Photos (2022)",
-  "description": "Invercargill 0.1m Rural Aerial Photos",
+  "description": "Invercargill 0.1m Urban Aerial Photos",
   "license": "CC-BY-4.0",
   "links": [
     { "rel": "self", "href": "./collection.json", "type": "application/json" },


### PR DESCRIPTION
https://data.linz.govt.nz/layer/110773-invercargill-01m-urban-aerial-photos-2022/