### PR TITLE
feat: add skip-workflows option [skip-argo]

### DIFF
--- a/.github/workflows/publish-to-odr.yml
+++ b/.github/workflows/publish-to-odr.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   main:
+    if: "!contains(github.event.head_commit.message, '[skip-workflows]')"
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/publish-to-odr.yml
+++ b/.github/workflows/publish-to-odr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   main:
-    if: "!contains(github.event.head_commit.message, '[skip-workflows]')"
+    if: "!contains(github.event.head_commit.message, '[skip-argo]')"
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/publish-odr-parameters/README.md
+++ b/publish-odr-parameters/README.md
@@ -37,7 +37,7 @@ Below is an example PR:
 
 ### Step 2a: if you dont want submit workflows
 There may be some cases when you dont want to submit workflows, for example reformatting files.   
-In this case add `[skip-workflows]` to the pull request title e.g- `fix[skip-workflows]: Reformatting parameter files`  
+In this case add `[skip-argo]` to the end of the pull request title e.g- `fix: Reformatting parameter files [skip-argo]`  
 
 ### Step 3: Approve and Merge Pull Request -> Submit Argo Workflow (Automated)
 

--- a/publish-odr-parameters/README.md
+++ b/publish-odr-parameters/README.md
@@ -37,8 +37,7 @@ Below is an example PR:
 
 ### Step 2a: if you dont want submit workflows
 There may be some cases when you dont want to submit workflows, for example reformatting files.   
-In this case add `[skip ci]` to the pull request title e.g- `fix[skip ci]: Reformatting parameter files`  
-[more information](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/) 
+In this case add `[skip-workflows]` to the pull request title e.g- `fix[skip-workflows]: Reformatting parameter files`  
 
 ### Step 3: Approve and Merge Pull Request -> Submit Argo Workflow (Automated)
 


### PR DESCRIPTION
changed from skip ci in [ ] to `[skip-workflows]` in the PR title

Now the publish workflow will still run (which is required for a merge to master) but the publish-odr workflow can still be skipped using a similar logic.