### PR TITLE
fix: revert temp change to trigger action [skip-argo]

### DIFF
--- a/publish-odr-parameters/2023/hurunui_2023_0.075m.yaml
+++ b/publish-odr-parameters/2023/hurunui_2023_0.075m.yaml
@@ -1,2 +1,2 @@
-'source': 's3://linz-workflow-artifacts/2023-11/09-ecan-hurunui-phw6r/flat/'
-'target': 's3://nz-imagery/canterbury/hurunui_2023_0.075m/rgb/2193/'
+source: 's3://linz-workflow-artifacts/2023-11/09-ecan-hurunui-phw6r/flat/'
+target: 's3://nz-imagery/canterbury/hurunui_2023_0.075m/rgb/2193/'


### PR DESCRIPTION
to get the publish-odr action to trigger after fixing a bug this file had to be modified. 

This pr is just reverting this change back to correct formatting - publish-odr will not be triggered.