### PR TITLE
feat: Pin actions to hashes TDE-934

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -7,7 +7,7 @@ jobs:
   create-pull-request:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
       - name: pull-request
         run: |

--- a/.github/workflows/publish-to-odr.yml
+++ b/.github/workflows/publish-to-odr.yml
@@ -21,22 +21,22 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
 
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: '18.x'
 
       - name: Setup kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
         with:
           version: 'latest'
 
       - name: AWS Configure
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Publish
 
-on: [push]
+on: [ push ]
 
 jobs:
   main:
@@ -9,7 +9,7 @@ jobs:
     concurrency: validate-${{ github.ref }}
 
     steps:
-      - uses: linz/action-typescript@v3
+      - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
 
       # FIXME: catalog.json is not pushed to the repository (temporary solution)
       - name: Create Catalog
@@ -44,7 +44,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: linz/action-typescript@v3
+      - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
 
       # FIXME: catalog.json is not pushed to the repository (temporary solution)
       - name: Create Catalog
@@ -59,14 +59,14 @@ jobs:
           docker run -v "${PWD}:${PWD}" ghcr.io/linz/argo-tasks:v2 stac-validate "$PWD"/stac/**/collection.json
 
       - name: AWS Configure
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_ODR_CI_ROLE }}
 
       - name: AWS Configure ODR
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true


### PR DESCRIPTION
Done with pin-github-action <https://github.com/mheap/pin-github-action> 1.8.0 using `npx pin-github-action .github/workflows/*.yml`.

Dependabot should support updating in the same fashion <https://github.com/dependabot/dependabot-core/issues/8277#issuecomment-1782819752>.

Had to `export GH_ADMIN_TOKEN=github_pat_…` using a fine-grained personal access tokens with no extra access to work around rate limiting *and* to be able to work in private repos
<https://github.com/mheap/pin-github-action/issues/73>.