### PR TITLE
ci: update cluster to workflows TDE-902

### DIFF
--- a/.github/workflows/publish-to-odr.yml
+++ b/.github/workflows/publish-to-odr.yml
@@ -20,6 +20,9 @@ jobs:
       id-token: write
       contents: read
 
+    env:
+      CLUSTER_NAME: Workflows
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +47,7 @@ jobs:
 
       - name: Login to EKS
         run: |
-          aws eks update-kubeconfig --name Workflows --region ap-southeast-2
+          aws eks update-kubeconfig --name ${{ env.CLUSTER_NAME }} --region ap-southeast-2
 
       - name: Check EKS connection
         run: |

--- a/.github/workflows/publish-to-odr.yml
+++ b/.github/workflows/publish-to-odr.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Login to EKS
         run: |
-          aws eks update-kubeconfig --name Workflow --region ap-southeast-2 --role-arn  ${{ secrets.AWS_EKS_ROLE }}
+          aws eks update-kubeconfig --name Workflows --region ap-southeast-2
 
       - name: Check EKS connection
         run: |


### PR DESCRIPTION
publish-to-odr github action updated to the new cluster in preparation for the switch. 

Connection tested on a separate branch: https://github.com/linz/imagery/actions/runs/6897417977/job/18770248994
(had to add the AWS_EKS_CI_ROLE secret to nonprod, I have deleted it, therefore re-running this job will fail) 