### PR TITLE
refactor: capitalise SKYVUW & SKYCAN TDE-1033

### DIFF
--- a/stac/auckland/auckland_sn5600_1979_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5600_1979_0.375m/rgb/2193/collection.json
@@ -83,7 +83,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/auckland/auckland_sn9211_1992_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9211_1992_0.4m/rgb/2193/collection.json
@@ -201,7 +201,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/auckland/auckland_snc50347_2003-2004_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_snc50347_2003-2004_0.75m/rgb/2193/collection.json
@@ -195,7 +195,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/auckland/auckland_waikato_sn8772_1987-1988_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_waikato_sn8772_1987-1988_0.375m/rgb/2193/collection.json
@@ -798,7 +798,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_gisborne_sn5975_1981_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_gisborne_sn5975_1981_0.375m/rgb/2193/collection.json
@@ -348,7 +348,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_gisborne_sn8564_1985_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_gisborne_sn8564_1985_0.375m/rgb/2193/collection.json
@@ -215,7 +215,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/rgb/2193/collection.json
@@ -301,7 +301,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_sn8240_1983_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8240_1983_0.75m/rgb/2193/collection.json
@@ -109,7 +109,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_sn8540_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8540_1985-1986_0.375m/rgb/2193/collection.json
@@ -221,7 +221,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_sn8626_1986_0.4m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8626_1986_0.4m/rgb/2193/collection.json
@@ -218,7 +218,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_sn8732_1987_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8732_1987_0.15m/rgb/2193/collection.json
@@ -955,7 +955,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_sn9383_1994_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn9383_1994_0.75m/rgb/2193/collection.json
@@ -80,7 +80,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_snc25059_2001_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_snc25059_2001_0.75m/rgb/2193/collection.json
@@ -56,7 +56,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_snc30006a_2002_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_snc30006a_2002_0.75m/rgb/2193/collection.json
@@ -174,7 +174,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_snc50515_2003_0.625m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_snc50515_2003_0.625m/rgb/2193/collection.json
@@ -67,7 +67,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/bay-of-plenty/bay-of-plenty_waikato_snc25058_2001_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_waikato_snc25058_2001_0.75m/rgb/2193/collection.json
@@ -123,7 +123,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_marlborough_sn8533_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_marlborough_sn8533_1985-1986_0.375m/rgb/2193/collection.json
@@ -434,7 +434,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_otago_sn8337_1984_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_otago_sn8337_1984_0.75m/rgb/2193/collection.json
@@ -59,7 +59,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_otago_sn8568_1985-1987_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_otago_sn8568_1985-1987_0.75m/rgb/2193/collection.json
@@ -322,7 +322,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn12542_1998_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn12542_1998_0.75m/rgb/2193/collection.json
@@ -144,7 +144,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn12543_1998-1999_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn12543_1998-1999_0.75m/rgb/2193/collection.json
@@ -164,7 +164,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn25022_2000_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn25022_2000_0.75m/rgb/2193/collection.json
@@ -81,7 +81,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn5204_1978_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn5204_1978_0.75m/rgb/2193/collection.json
@@ -165,7 +165,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn5771_1980-1981_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn5771_1980-1981_0.375m/rgb/2193/collection.json
@@ -199,7 +199,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8261_1983_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8261_1983_0.75m/rgb/2193/collection.json
@@ -79,7 +79,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8389_1984_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8389_1984_0.375m/rgb/2193/collection.json
@@ -491,7 +491,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8453_1985_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8453_1985_0.75m/rgb/2193/collection.json
@@ -283,7 +283,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8532_1985_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8532_1985_0.375m/rgb/2193/collection.json
@@ -397,7 +397,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8569_1985-1986_0.8m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8569_1985-1986_0.8m/rgb/2193/collection.json
@@ -197,7 +197,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8584_1986_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8584_1986_0.75m/rgb/2193/collection.json
@@ -294,7 +294,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8720_1987_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8720_1987_0.375m/rgb/2193/collection.json
@@ -460,7 +460,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn8777_1987_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8777_1987_0.375m/rgb/2193/collection.json
@@ -315,7 +315,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn9381_1994_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn9381_1994_0.75m/rgb/2193/collection.json
@@ -138,7 +138,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_sn9447_1995_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn9447_1995_0.75m/rgb/2193/collection.json
@@ -62,7 +62,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_snc25051_2000_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc25051_2000_0.75m/rgb/2193/collection.json
@@ -93,7 +93,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_snc25053_2001_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc25053_2001_0.75m/rgb/2193/collection.json
@@ -131,7 +131,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_snc25054_2000-2001_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc25054_2000-2001_0.75m/rgb/2193/collection.json
@@ -165,7 +165,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_snc30000_2002_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc30000_2002_0.75m/rgb/2193/collection.json
@@ -87,7 +87,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_snc30009_2003_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc30009_2003_0.75m/rgb/2193/collection.json
@@ -74,7 +74,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/canterbury/canterbury_west-coast_sn8595_1986-1987_0.96m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_west-coast_sn8595_1986-1987_0.96m/rgb/2193/collection.json
@@ -428,7 +428,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_bay-of-plenty_sn5766_1980_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_bay-of-plenty_sn5766_1980_0.375m/rgb/2193/collection.json
@@ -216,7 +216,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_sn12540_1998_0.75m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn12540_1998_0.75m/rgb/2193/collection.json
@@ -64,7 +64,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_sn8132_1982_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8132_1982_0.375m/rgb/2193/collection.json
@@ -477,7 +477,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_sn8418_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8418_1984-1985_0.375m/rgb/2193/collection.json
@@ -408,7 +408,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_sn8538_1985_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8538_1985_0.375m/rgb/2193/collection.json
@@ -170,7 +170,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_sn8941_1988_0.15m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8941_1988_0.15m/rgb/2193/collection.json
@@ -415,7 +415,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_snc25046_2000_0.75m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_snc25046_2000_0.75m/rgb/2193/collection.json
@@ -60,7 +60,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/gisborne/gisborne_snc8309_1983_0.4m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_snc8309_1983_0.4m/rgb/2193/collection.json
@@ -122,7 +122,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/rgb/2193/collection.json
@@ -6175,7 +6175,7 @@
   ],
   "providers": [
     { "name": "Hawke's Bay Regional Council", "roles": ["licensor"] },
-    { "name": "SkyCan", "roles": ["producer"] },
+    { "name": "SKYCAN", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
   "extent": {

--- a/stac/hawkes-bay/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/rgb/2193/collection.json
@@ -69,7 +69,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/rgb/2193/collection.json
@@ -707,7 +707,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/rgb/2193/collection.json
@@ -635,7 +635,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/rgb/2193/collection.json
@@ -130,7 +130,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn7786_1989_0.48m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn7786_1989_0.48m/rgb/2193/collection.json
@@ -121,7 +121,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn8675_1986_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn8675_1986_0.375m/rgb/2193/collection.json
@@ -126,7 +126,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn8985_1988_0.4m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn8985_1988_0.4m/rgb/2193/collection.json
@@ -396,7 +396,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn9037_1989_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9037_1989_0.75m/rgb/2193/collection.json
@@ -54,7 +54,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn9410_1995_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9410_1995_0.375m/rgb/2193/collection.json
@@ -326,7 +326,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn9452_1995_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9452_1995_0.375m/rgb/2193/collection.json
@@ -544,7 +544,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn9485_1995-1996_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9485_1995-1996_0.375m/rgb/2193/collection.json
@@ -901,7 +901,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_sn9585_1996_0.8m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9585_1996_0.8m/rgb/2193/collection.json
@@ -152,7 +152,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_snc50126_2003_0.6m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50126_2003_0.6m/rgb/2193/collection.json
@@ -173,7 +173,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_snc50450_2004_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50450_2004_0.75m/rgb/2193/collection.json
@@ -129,7 +129,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_snc50518_2004_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50518_2004_0.75m/rgb/2193/collection.json
@@ -69,7 +69,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_snc50519_2004_0.64m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50519_2004_0.64m/rgb/2193/collection.json
@@ -68,7 +68,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_snc50520_2004_0.64m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50520_2004_0.64m/rgb/2193/collection.json
@@ -60,7 +60,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_snc8912_1987_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc8912_1987_0.375m/rgb/2193/collection.json
@@ -79,7 +79,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/hawkes-bay/hawkes-bay_waikato_sn8260_1983_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_waikato_sn8260_1983_0.75m/rgb/2193/collection.json
@@ -280,7 +280,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/rgb/2193/collection.json
@@ -259,7 +259,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/rgb/2193/collection.json
@@ -71,7 +71,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn25017_2000_0.64m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn25017_2000_0.64m/rgb/2193/collection.json
@@ -99,7 +99,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn5291_1978_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn5291_1978_0.375m/rgb/2193/collection.json
@@ -353,7 +353,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn5408_1979-1980_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn5408_1979-1980_0.375m/rgb/2193/collection.json
@@ -350,7 +350,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8005_1982_0.8m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8005_1982_0.8m/rgb/2193/collection.json
@@ -147,7 +147,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8158_1983_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8158_1983_0.4m/rgb/2193/collection.json
@@ -224,7 +224,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8303_1984_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8303_1984_0.375m/rgb/2193/collection.json
@@ -223,7 +223,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8316_1984_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8316_1984_0.4m/rgb/2193/collection.json
@@ -226,7 +226,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn9158_1991_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn9158_1991_0.375m/rgb/2193/collection.json
@@ -69,7 +69,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn9364_1994_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn9364_1994_0.375m/rgb/2193/collection.json
@@ -39,7 +39,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn9470_1995-1996_0.8m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn9470_1995-1996_0.8m/rgb/2193/collection.json
@@ -191,7 +191,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc12781_2003_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc12781_2003_0.75m/rgb/2193/collection.json
@@ -92,7 +92,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc25045_2001_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc25045_2001_0.75m/rgb/2193/collection.json
@@ -106,7 +106,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc25061_2001_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc25061_2001_0.75m/rgb/2193/collection.json
@@ -124,7 +124,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc8650_1986_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc8650_1986_0.375m/rgb/2193/collection.json
@@ -248,7 +248,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc8914_1988_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc8914_1988_0.375m/rgb/2193/collection.json
@@ -81,7 +81,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8004_1982_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8004_1982_0.75m/rgb/2193/collection.json
@@ -137,7 +137,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8157_1983_0.8m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8157_1983_0.8m/rgb/2193/collection.json
@@ -132,7 +132,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8549_1985_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8549_1985_0.375m/rgb/2193/collection.json
@@ -449,7 +449,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/rgb/2193/collection.json
@@ -197,7 +197,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/rgb/2193/collection.json
@@ -394,7 +394,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/rgb/2193/collection.json
@@ -384,7 +384,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9284_1993_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9284_1993_0.75m/rgb/2193/collection.json
@@ -57,7 +57,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9911_2000_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9911_2000_0.75m/rgb/2193/collection.json
@@ -79,7 +79,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
@@ -3498,7 +3498,7 @@
     { "rel": "item", "href": "./BS29_500_007044.json", "type": "application/json" }
   ],
   "providers": [
-    { "name": "SkyCan", "roles": ["producer"] },
+    { "name": "SKYCAN", "roles": ["producer"] },
     { "name": "Marlborough District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],

--- a/stac/marlborough/marlborough_sn5100_1977_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn5100_1977_0.75m/rgb/2193/collection.json
@@ -47,7 +47,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn5638_1979-1980_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn5638_1979-1980_0.375m/rgb/2193/collection.json
@@ -203,7 +203,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn8000_1982_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8000_1982_0.75m/rgb/2193/collection.json
@@ -176,7 +176,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn8049_1982_0.8m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8049_1982_0.8m/rgb/2193/collection.json
@@ -48,7 +48,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn8200_1983_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8200_1983_0.375m/rgb/2193/collection.json
@@ -179,7 +179,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn8262_1983_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8262_1983_0.375m/rgb/2193/collection.json
@@ -356,7 +356,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn9360_1994_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn9360_1994_0.75m/rgb/2193/collection.json
@@ -122,7 +122,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn9471_1995_0.8m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn9471_1995_0.8m/rgb/2193/collection.json
@@ -43,7 +43,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_sn9586_1996_0.32m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn9586_1996_0.32m/rgb/2193/collection.json
@@ -137,7 +137,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_snc25048_2000_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc25048_2000_0.75m/rgb/2193/collection.json
@@ -66,7 +66,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_snc2887_1975_0.3m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc2887_1975_0.3m/rgb/2193/collection.json
@@ -72,7 +72,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_snc30007_2002_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc30007_2002_0.75m/rgb/2193/collection.json
@@ -63,7 +63,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_snc8294_1983_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc8294_1983_0.375m/rgb/2193/collection.json
@@ -204,7 +204,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_tasman_canterbury_sn8452_1985_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_tasman_canterbury_sn8452_1985_0.75m/rgb/2193/collection.json
@@ -219,7 +219,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_tasman_sn8415_1984_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_tasman_sn8415_1984_0.375m/rgb/2193/collection.json
@@ -373,7 +373,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_tasman_snc8423_1984_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_tasman_snc8423_1984_0.375m/rgb/2193/collection.json
@@ -254,7 +254,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/marlborough/marlborough_wellington_snc50451_2004-2005_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_wellington_snc50451_2004-2005_0.75m/rgb/2193/collection.json
@@ -419,7 +419,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_auckland_sn8104_1982-1983_0.4m/rgb/2193/collection.json
+++ b/stac/northland/northland_auckland_sn8104_1982-1983_0.4m/rgb/2193/collection.json
@@ -543,7 +543,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_auckland_sn9482_1995-1996_0.8m/rgb/2193/collection.json
+++ b/stac/northland/northland_auckland_sn9482_1995-1996_0.8m/rgb/2193/collection.json
@@ -183,7 +183,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_sn5780_1980_0.8m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn5780_1980_0.8m/rgb/2193/collection.json
@@ -70,7 +70,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_sn5932_1981-1982_0.375m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn5932_1981-1982_0.375m/rgb/2193/collection.json
@@ -692,7 +692,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_sn8328_1984-1986_0.8m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn8328_1984-1986_0.8m/rgb/2193/collection.json
@@ -223,7 +223,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_sn9281_1993_0.6m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn9281_1993_0.6m/rgb/2193/collection.json
@@ -59,7 +59,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_snc12835_2005_0.64m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc12835_2005_0.64m/rgb/2193/collection.json
@@ -164,7 +164,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_snc5797_1980_0.375m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc5797_1980_0.375m/rgb/2193/collection.json
@@ -63,7 +63,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_snc8573_1985_0.3m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc8573_1985_0.3m/rgb/2193/collection.json
@@ -57,7 +57,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/northland/northland_snc9935_2000-2003_0.75m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc9935_2000-2003_0.75m/rgb/2193/collection.json
@@ -275,7 +275,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_canterbury_sn9933_2000_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_canterbury_sn9933_2000_0.75m/rgb/2193/collection.json
@@ -196,7 +196,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn12544_1998_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn12544_1998_0.75m/rgb/2193/collection.json
@@ -87,7 +87,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn3806_1975_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn3806_1975_0.375m/rgb/2193/collection.json
@@ -277,7 +277,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn5220_1978_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn5220_1978_0.75m/rgb/2193/collection.json
@@ -164,7 +164,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn5359_1979_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn5359_1979_0.375m/rgb/2193/collection.json
@@ -358,7 +358,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn8180_1983_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8180_1983_0.75m/rgb/2193/collection.json
@@ -187,7 +187,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn8215_1983-1984_0.8m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8215_1983-1984_0.8m/rgb/2193/collection.json
@@ -143,7 +143,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn8286_1984_0.8m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8286_1984_0.8m/rgb/2193/collection.json
@@ -251,7 +251,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn8436_1984_0.64m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8436_1984_0.64m/rgb/2193/collection.json
@@ -278,7 +278,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn8479_1985_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8479_1985_0.375m/rgb/2193/collection.json
@@ -200,7 +200,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn8733_1987_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8733_1987_0.375m/rgb/2193/collection.json
@@ -228,7 +228,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn9087_1990-1991_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn9087_1990-1991_0.75m/rgb/2193/collection.json
@@ -196,7 +196,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn9457_1995-1997_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn9457_1995-1997_0.75m/rgb/2193/collection.json
@@ -131,7 +131,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_sn9937_2000_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn9937_2000_0.75m/rgb/2193/collection.json
@@ -78,7 +78,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_snc12780_2003_0.64m/rgb/2193/collection.json
+++ b/stac/otago/otago_snc12780_2003_0.64m/rgb/2193/collection.json
@@ -253,7 +253,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_snc25055_2001_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_snc25055_2001_0.75m/rgb/2193/collection.json
@@ -137,7 +137,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_snc25057_2001_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_snc25057_2001_0.75m/rgb/2193/collection.json
@@ -305,7 +305,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/otago/otago_southland_west-coast_sn8426_1984-1985_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_southland_west-coast_sn8426_1984-1985_0.75m/rgb/2193/collection.json
@@ -163,7 +163,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_sn5693_1980_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn5693_1980_0.75m/rgb/2193/collection.json
@@ -172,7 +172,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_sn8542_1985_0.375m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn8542_1985_0.375m/rgb/2193/collection.json
@@ -339,7 +339,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_sn8565_1985-1987_0.8m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn8565_1985-1987_0.8m/rgb/2193/collection.json
@@ -319,7 +319,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_sn8996_1988_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn8996_1988_0.75m/rgb/2193/collection.json
@@ -210,7 +210,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_sn9613_1997_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn9613_1997_0.75m/rgb/2193/collection.json
@@ -229,7 +229,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_snc12731_2002_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_snc12731_2002_0.75m/rgb/2193/collection.json
@@ -88,7 +88,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_otago_snc30012_2003_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_snc30012_2003_0.75m/rgb/2193/collection.json
@@ -135,7 +135,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn12545a_1998_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn12545a_1998_0.75m/rgb/2193/collection.json
@@ -88,7 +88,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn8038_1982_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8038_1982_0.75m/rgb/2193/collection.json
@@ -144,7 +144,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn8317_1984_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8317_1984_0.75m/rgb/2193/collection.json
@@ -138,7 +138,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn8408_1984_0.375m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8408_1984_0.375m/rgb/2193/collection.json
@@ -381,7 +381,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn8541_1985_0.375m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8541_1985_0.375m/rgb/2193/collection.json
@@ -159,7 +159,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn9066_1990-1991_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn9066_1990-1991_0.75m/rgb/2193/collection.json
@@ -32,7 +32,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn9067_1990_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn9067_1990_0.75m/rgb/2193/collection.json
@@ -72,7 +72,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_sn9421_1995_0.25m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn9421_1995_0.25m/rgb/2193/collection.json
@@ -140,7 +140,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_snc30005a_2002_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_snc30005a_2002_0.75m/rgb/2193/collection.json
@@ -228,7 +228,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_snc30005b_2003_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_snc30005b_2003_0.75m/rgb/2193/collection.json
@@ -175,7 +175,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/southland/southland_snc30011_2003_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_snc30011_2003_0.75m/rgb/2193/collection.json
@@ -95,7 +95,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_manawatu-whanganui_sn8463_1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_manawatu-whanganui_sn8463_1985_0.375m/rgb/2193/collection.json
@@ -203,7 +203,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn25016_2000_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn25016_2000_0.75m/rgb/2193/collection.json
@@ -49,7 +49,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn5804_1981_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn5804_1981_0.375m/rgb/2193/collection.json
@@ -186,7 +186,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8003_1982_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8003_1982_0.75m/rgb/2193/collection.json
@@ -173,7 +173,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8008_1982_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8008_1982_0.375m/rgb/2193/collection.json
@@ -171,7 +171,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8298_1984_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8298_1984_0.375m/rgb/2193/collection.json
@@ -160,7 +160,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8349_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8349_1984-1985_0.375m/rgb/2193/collection.json
@@ -161,7 +161,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8422_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8422_1984-1985_0.375m/rgb/2193/collection.json
@@ -232,7 +232,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8502_1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8502_1985_0.375m/rgb/2193/collection.json
@@ -62,7 +62,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_sn8771_1988_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8771_1988_0.375m/rgb/2193/collection.json
@@ -118,7 +118,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_snc25044_2001_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_snc25044_2001_0.75m/rgb/2193/collection.json
@@ -148,7 +148,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_snc30004_2002_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_snc30004_2002_0.75m/rgb/2193/collection.json
@@ -72,7 +72,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/taranaki/taranaki_snc8923_1988_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_snc8923_1988_0.375m/rgb/2193/collection.json
@@ -41,7 +41,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_marlborough_nelson_sn25020_2000_0.75m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_marlborough_nelson_sn25020_2000_0.75m/rgb/2193/collection.json
@@ -136,7 +136,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_sn8209_1983_0.8m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_sn8209_1983_0.8m/rgb/2193/collection.json
@@ -73,7 +73,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_sn8531_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_sn8531_1985-1986_0.375m/rgb/2193/collection.json
@@ -274,7 +274,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_sn8821_1991_0.6m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_sn8821_1991_0.6m/rgb/2193/collection.json
@@ -77,7 +77,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_snc25049_2000_0.75m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc25049_2000_0.75m/rgb/2193/collection.json
@@ -80,7 +80,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_snc30002_2002_0.75m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc30002_2002_0.75m/rgb/2193/collection.json
@@ -64,7 +64,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_snc5676_1980-1981_0.64m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc5676_1980-1981_0.64m/rgb/2193/collection.json
@@ -379,7 +379,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_snc8054_1982_0.25m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc8054_1982_0.25m/rgb/2193/collection.json
@@ -101,7 +101,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_west-coast_sn8409_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_west-coast_sn8409_1984-1985_0.375m/rgb/2193/collection.json
@@ -519,7 +519,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/tasman/tasman_west-coast_snc50452_2004-2005_0.64m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_west-coast_snc50452_2004-2005_0.64m/rgb/2193/collection.json
@@ -253,7 +253,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_auckland_sn9919_2000_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_auckland_sn9919_2000_0.75m/rgb/2193/collection.json
@@ -88,7 +88,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_bay-of-plenty_sn12539_1999_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn12539_1999_0.75m/rgb/2193/collection.json
@@ -90,7 +90,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/rgb/2193/collection.json
@@ -389,7 +389,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/rgb/2193/collection.json
@@ -693,7 +693,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/rgb/2193/collection.json
@@ -235,7 +235,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_bay-of-plenty_snc12836_2004_0.625m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_snc12836_2004_0.625m/rgb/2193/collection.json
@@ -64,7 +64,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_bay-of-plenty_snc25060_2001_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_snc25060_2001_0.75m/rgb/2193/collection.json
@@ -84,7 +84,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn5164_1977-1979_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn5164_1977-1979_0.375m/rgb/2193/collection.json
@@ -472,7 +472,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn5479_1979_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn5479_1979_0.375m/rgb/2193/collection.json
@@ -543,7 +543,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn6656_1985-1987_0.6m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn6656_1985-1987_0.6m/rgb/2193/collection.json
@@ -77,7 +77,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn8163_1983-1984_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8163_1983-1984_0.375m/rgb/2193/collection.json
@@ -422,7 +422,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn8166_1983_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8166_1983_0.75m/rgb/2193/collection.json
@@ -187,7 +187,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn8297_1984_0.4m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8297_1984_0.4m/rgb/2193/collection.json
@@ -385,7 +385,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn8687_1986-1987_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8687_1986-1987_0.375m/rgb/2193/collection.json
@@ -160,7 +160,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn9124_1990-1991_0.48m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9124_1990-1991_0.48m/rgb/2193/collection.json
@@ -704,7 +704,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn9361_1994-1995_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9361_1994-1995_0.75m/rgb/2193/collection.json
@@ -97,7 +97,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn9401_1995_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9401_1995_0.75m/rgb/2193/collection.json
@@ -148,7 +148,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn9584_1996-1997_0.64m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9584_1996-1997_0.64m/rgb/2193/collection.json
@@ -120,7 +120,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn9615_1997_0.8m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9615_1997_0.8m/rgb/2193/collection.json
@@ -132,7 +132,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_sn9859_1999_0.625m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9859_1999_0.625m/rgb/2193/collection.json
@@ -311,7 +311,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_snc12837_2003_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc12837_2003_0.75m/rgb/2193/collection.json
@@ -70,7 +70,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_snc5876_1981_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc5876_1981_0.375m/rgb/2193/collection.json
@@ -100,7 +100,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_snc8697_1986_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc8697_1986_0.375m/rgb/2193/collection.json
@@ -46,7 +46,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/waikato/waikato_snc9990_2001-2003_0.6m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc9990_2001-2003_0.6m/rgb/2193/collection.json
@@ -997,7 +997,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_manawatu-whanganui_sn5139_1977_0.375m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn5139_1977_0.375m/rgb/2193/collection.json
@@ -476,7 +476,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/rgb/2193/collection.json
@@ -157,7 +157,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_manawatu-whanganui_sn8171_1983_0.375m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn8171_1983_0.375m/rgb/2193/collection.json
@@ -262,7 +262,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/rgb/2193/collection.json
@@ -216,7 +216,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_sn5497_1979-1980_0.4m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn5497_1979-1980_0.4m/rgb/2193/collection.json
@@ -555,7 +555,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_sn8790_1987-1988_0.375m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn8790_1987-1988_0.375m/rgb/2193/collection.json
@@ -291,7 +291,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_sn9448_1995-1997_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn9448_1995-1997_0.75m/rgb/2193/collection.json
@@ -118,7 +118,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_snc25047_2000_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_snc25047_2000_0.75m/rgb/2193/collection.json
@@ -76,7 +76,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_snc25062_2000_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_snc25062_2000_0.75m/rgb/2193/collection.json
@@ -87,7 +87,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/wellington/wellington_snc30010_2002_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_snc30010_2002_0.75m/rgb/2193/collection.json
@@ -78,7 +78,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_canterbury_sn8585_1986-1987_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_canterbury_sn8585_1986-1987_0.75m/rgb/2193/collection.json
@@ -257,7 +257,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_otago_sn8321_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_otago_sn8321_1984-1985_0.375m/rgb/2193/collection.json
@@ -381,7 +381,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_otago_sn9065_1990_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_otago_sn9065_1990_0.75m/rgb/2193/collection.json
@@ -137,7 +137,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn5781_1980_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn5781_1980_0.375m/rgb/2193/collection.json
@@ -87,7 +87,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn5817_1980_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn5817_1980_0.375m/rgb/2193/collection.json
@@ -124,7 +124,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn8312_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn8312_1984-1985_0.375m/rgb/2193/collection.json
@@ -526,7 +526,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn8534_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn8534_1985-1986_0.375m/rgb/2193/collection.json
@@ -468,7 +468,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn8721_1987_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn8721_1987_0.375m/rgb/2193/collection.json
@@ -235,7 +235,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn9493_1996_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn9493_1996_0.75m/rgb/2193/collection.json
@@ -125,7 +125,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_sn9641_1997_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn9641_1997_0.75m/rgb/2193/collection.json
@@ -178,7 +178,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],

--- a/stac/west-coast/west-coast_snc30003_2002_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_snc30003_2002_0.75m/rgb/2193/collection.json
@@ -76,7 +76,7 @@
   ],
   "providers": [
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
-    { "name": "Skyvuw", "roles": ["producer"] },
+    { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],


### PR DESCRIPTION
#### Motivation

Capitalise SKYCAN and SKYVUW so that public documentation is consistent with company conventions.

#### Modification

Find and replace:
- `skycan` / `SkyCan` / `Skycan` -> `SKYCAN`
- `skyvuw` / `SkyVuw` / `Skyvuw` -> `SKYVUW`
(mostly historical imagery)

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated - n/a
- [ ] Docs updated - n/a
- [x] Issue linked in Title