### PR TITLE
ci: remove parameters yaml filename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,7 @@ jobs:
 
           for file in "${modified_parameter_files[@]}"; do
             base=$(basename "${file%.yaml}")
-            ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" --generate-name "publish-odr-$base-"
+            ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" --generate-name "publish-odr-"
           done
 
       - name: AWS Configure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,7 +111,6 @@ jobs:
           mapfile -d '' modified_parameter_files < <(git diff --name-only --diff-filter=AM -z ${{ github.event.before }} ${{ github.event.after }} -- "publish-odr-parameters/*.yaml")
 
           for file in "${modified_parameter_files[@]}"; do
-            base=$(basename "${file%.yaml}")
             ./argo-linux-amd64 submit --wait --from wftmpl/copy -n argo -f "$file" -p aws_role_config_path="s3://linz-bucket-config/config-write.open-data-registry.json" --generate-name "publish-odr-"
           done
 


### PR DESCRIPTION
The logic to use `$base` (the name of the parameters.yaml file) to name the argo workflow submitted no longer works. 
https://github.com/linz/imagery/actions/runs/8413556393

This change will give each submission the name `publish-odr-`

In future we could update this to include the name of the branch/pull request however as the action is currently broken this is the quickest solution.