### PR TITLE
fix: copy without failing on collection.json TDE-1107

### DIFF
--- a/publish-odr-parameters/01HSSD824MS222RR0W044QZADV-1711327325496.yaml
+++ b/publish-odr-parameters/01HSSD824MS222RR0W044QZADV-1711327325496.yaml
@@ -1,7 +1,7 @@
 {
   "source": "s3://linz-workflows-scratch/2024-03/24-imagery-standardising-52bts/flat/",
   "target": "s3://nz-imagery/new-zealand/new-zealand_2021-2022_10m/rgb/2193/",
-  "ticket": "TDE-1099",
+  "ticket": "TDE-1107",
   "copy_option": "--no-clobber",
   "region": "new-zealand"
 }


### PR DESCRIPTION
Retry the copy of the 2020-2021 satellite imagery. It should not try to copy the `collection.json` file from the scratch bucket location.