### PR TITLE
fix: correct category in title to match dataset category

### DIFF
--- a/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01HTNPANWSRJKV8VS62H8XD5K1",
-  "title": "Bay of Plenty 0.2m Urban Aerial Photos (2023-2024)",
+  "title": "Bay of Plenty 0.2m Rural Aerial Photos (2023-2024)",
   "description": "Orthophotography within the Bay of Plenty region captured in the 2023-2024 flying season.",
   "license": "CC-BY-4.0",
   "links": [


### PR DESCRIPTION
At time of import, category was updated to `rural-aerial-photos` from `urban-aerial-photos`, however the title of the dataset was not updated.

This fix will make the title consistent with the category.
