### PR TITLE
fix: correct producer of bay-of-plenty_2023-2024_0.2m

### DIFF
--- a/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
@@ -386,7 +386,7 @@
     { "rel": "item", "href": "./BE42_5000_0402.json", "type": "application/json" }
   ],
   "providers": [
-    { "name": "Aerial Surveys", "roles": ["producer"] },
+    { "name": "Woolpert", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "National Institute of Water and Atmospheric Research", "roles": ["licensor"] }
   ],


### PR DESCRIPTION
Changing producer from Aerial Surveys to Woolpert.