### PR TITLE
fix: add metre symbol to gsd in title

### DIFF
--- a/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01HHK73XJPH6P621W9HZXM4JK6",
-  "title": "Auckland Coast 0.05 Urban Aerial Photos (2022-2023) - Draft",
+  "title": "Auckland Coast 0.05m Urban Aerial Photos (2022-2023) - Draft",
   "description": "Orthophotography within the Auckland region captured in the 2022-2023 flying season, published as a record of the Cyclone Gabrielle event.",
   "license": "CC-BY-4.0",
   "links": [

--- a/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01J02D14MPWA4MSEPC4N7Y42DY",
-  "title": "Auckland Coast 0.05 Urban Aerial Photos (2023) - Draft",
+  "title": "Auckland Coast 0.05m Urban Aerial Photos (2023) - Draft",
   "description": "Orthophotography within the Auckland region captured in the 2023 flying season, published as a record of the Cyclone Gabrielle event.",
   "license": "CC-BY-4.0",
   "links": [


### PR DESCRIPTION
The title is missing the metre symbol following the GSD in the dataset's title.