### PR TITLE
feat: backfill linz:slug attribute in collection.json files

### DIFF
--- a/stac/auckland/auckland-central_2023_0.06m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-central_2023_0.06m/rgb/2193/collection.json
@@ -150,6 +150,7 @@
   "linz:region": "auckland",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Auckland Central",
+  "linz:slug": "auckland-central_2023_0.06m",
   "extent": {
     "spatial": { "bbox": [[174.69658, -37.0338173, 174.8390448, -36.8132459]] },
     "temporal": { "interval": [["2023-08-21T12:00:00Z", "2023-08-23T12:00:00Z"]] }

--- a/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
@@ -27174,6 +27174,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Cyclone Gabrielle",
   "linz:geographic_description": "Auckland Coast",
+  "linz:slug": "auckland-coast_2022-2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[174.1568679, -37.3015115, 175.5557893, -36.0426247]] },
     "temporal": { "interval": [["2022-11-25T11:00:00Z", "2023-01-22T11:00:00Z"]] }

--- a/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
@@ -18234,6 +18234,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Cyclone Gabrielle",
   "linz:geographic_description": "Auckland Coast",
+  "linz:slug": "auckland-coast_2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[174.3601035, -37.3015115, 175.293521, -36.1271042]] },
     "temporal": { "interval": [["2023-02-17T11:00:00Z", "2023-03-11T11:00:00Z"]] }

--- a/stac/auckland/auckland_2010-2011_0.125m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010-2011_0.125m/rgb/2193/collection.json
@@ -4625,6 +4625,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2010-2011_0.125m",
   "extent": {
     "spatial": { "bbox": [[174.2377052, -37.2909366, 175.517143, -36.1465019]] },
     "temporal": { "interval": [["2011-09-05T12:00:00Z", "2011-09-05T12:00:00Z"]] }

--- a/stac/auckland/auckland_2010-2012_0.5m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010-2012_0.5m/rgb/2193/collection.json
@@ -289,6 +289,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2010-2012_0.5m",
   "extent": {
     "spatial": { "bbox": [[174.1503643, -37.3955883, 175.5940431, -35.8323605]] },
     "temporal": { "interval": [["2010-10-30T11:00:00Z", "2012-05-02T12:00:00Z"]] }

--- a/stac/auckland/auckland_2010_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010_0.075m/rgb/2193/collection.json
@@ -488,6 +488,7 @@
     { "name": "Auckland Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2010_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.629357, -36.8388752, 174.8139454, -36.6576222]] },
     "temporal": { "interval": [["2010-01-05T11:00:00Z", "2010-04-07T12:00:00Z"]] }

--- a/stac/auckland/auckland_2012_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2012_0.075m/rgb/2193/collection.json
@@ -203,6 +203,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2012_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.5870215, -36.9619722, 175.0287917, -36.6114889]] },
     "temporal": { "interval": [["2012-01-23T11:00:00Z", "2012-03-04T11:00:00Z"]] }

--- a/stac/auckland/auckland_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2015-2016_0.075m/rgb/2193/collection.json
@@ -4853,6 +4853,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2015-2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.2564143, -37.2897725, 175.5226914, -36.139909]] },
     "temporal": { "interval": [["2015-11-12T11:00:00Z", "2016-04-26T12:00:00Z"]] }

--- a/stac/auckland/auckland_2017_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2017_0.075m/rgb/2193/collection.json
@@ -7819,6 +7819,7 @@
     { "name": "Auckland Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2017_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.2322456, -37.2897725, 175.5226914, -36.139909]] },
     "temporal": { "interval": [["2017-03-14T11:00:00Z", "2017-05-05T12:00:00Z"]] }

--- a/stac/auckland/auckland_2020_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2020_0.075m/rgb/2193/collection.json
@@ -6611,6 +6611,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.4036448, -37.2315784, 175.5557893, -36.0230606]] },
     "temporal": { "interval": [["2020-03-14T11:00:00Z", "2020-12-29T11:00:00Z"]] }

--- a/stac/auckland/auckland_2022_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2022_0.075m/rgb/2193/collection.json
@@ -5638,6 +5638,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "auckland_2022_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.1568679, -37.2950242, 174.9803856, -36.1142716]] },
     "temporal": { "interval": [["2022-01-03T11:00:00Z", "2022-02-14T11:00:00Z"]] }

--- a/stac/auckland/auckland_2024_0.25m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2024_0.25m/rgb/2193/collection.json
@@ -1386,6 +1386,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-06-27T04:30:22Z",
   "updated": "2024-09-06T02:44:40Z",
+  "linz:slug": "auckland_2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[174.233687, -37.1732183, 174.8088539, -36.4916071]] },
     "temporal": { "interval": [["2024-03-19T11:00:00Z", "2024-05-10T12:00:00Z"]] }

--- a/stac/auckland/auckland_sn5600_1979_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5600_1979_0.375m/rgb/2193/collection.json
@@ -87,6 +87,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "auckland_sn5600_1979_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.2677418, -36.3784411, 175.5673248, -36.0228458]] },
     "temporal": { "interval": [["1979-10-23T12:00:00Z", "1979-10-23T12:00:00Z"]] }

--- a/stac/auckland/auckland_sn9211_1992_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9211_1992_0.4m/rgb/2193/collection.json
@@ -205,6 +205,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "auckland_sn9211_1992_0.4m",
   "extent": {
     "spatial": { "bbox": [[174.175163, -36.5263481, 174.8731829, -36.2287067]] },
     "temporal": { "interval": [["1992-02-28T11:00:00Z", "1992-02-29T11:00:00Z"]] }

--- a/stac/auckland/auckland_snc50347_2003-2004_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_snc50347_2003-2004_0.75m/rgb/2193/collection.json
@@ -199,6 +199,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "auckland_snc50347_2003-2004_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.2058653, -37.3346925, 175.4106254, -36.4939027]] },
     "temporal": { "interval": [["2003-11-17T11:00:00Z", "2004-01-01T11:00:00Z"]] }

--- a/stac/auckland/auckland_waikato_sn8772_1987-1988_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_waikato_sn8772_1987-1988_0.375m/rgb/2193/collection.json
@@ -802,6 +802,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "auckland_waikato_sn8772_1987-1988_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.1518009, -37.3984386, 175.5459349, -36.4307405]] },
     "temporal": { "interval": [["1987-10-20T12:00:00Z", "1988-03-19T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2010-2011_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2010-2011_0.125m/rgb/2193/collection.json
@@ -1581,6 +1581,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2010-2011_0.125m",
   "extent": {
     "spatial": { "bbox": [[176.031146, -38.468168, 177.1482548, -37.6205734]] },
     "temporal": { "interval": [["2010-12-28T11:00:00Z", "2011-03-31T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2011-2012_0.25m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2011-2012_0.25m/rgb/2193/collection.json
@@ -3379,6 +3379,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2011-2012_0.25m",
   "extent": {
     "spatial": { "bbox": [[175.8523926, -38.5825462, 177.4336498, -37.3607789]] },
     "temporal": { "interval": [["2011-03-07T11:00:00Z", "2012-01-24T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2014-2015_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2014-2015_0.125m/rgb/2193/collection.json
@@ -2713,6 +2713,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2014-2015_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.9024917, -38.051425, 177.4422068, -37.3865694]] },
     "temporal": { "interval": [["2014-12-02T11:00:00Z", "2015-02-28T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.125m/rgb/2193/collection.json
@@ -1036,6 +1036,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2015-2016_0.125m",
   "extent": {
     "spatial": { "bbox": [[176.064754, -38.4779038, 177.0216388, -37.7364671]] },
     "temporal": { "interval": [["2016-01-08T11:00:00Z", "2016-04-13T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.1m/rgb/2193/collection.json
@@ -77,6 +77,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2015-2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.8578196, -37.8707233, 176.2904584, -37.4193809]] },
     "temporal": { "interval": [["2016-01-08T11:00:00Z", "2016-04-13T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2015-2017_0.25m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2015-2017_0.25m/rgb/2193/collection.json
@@ -2640,6 +2640,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2015-2017_0.25m",
   "extent": {
     "spatial": { "bbox": [[175.973411, -38.5825462, 177.4336498, -37.8708673]] },
     "temporal": { "interval": [["2016-03-02T11:00:00Z", "2017-03-16T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2016-2017_0.3m/rgb/2193/collection.json
@@ -1395,6 +1395,7 @@
     { "name": "BOPLASS", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2016-2017_0.3m",
   "extent": {
     "spatial": { "bbox": [[175.7954587, -39.0168413, 178.1994095, -37.2353163]] },
     "temporal": { "interval": [["2016-11-08T11:00:00Z", "2017-02-09T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2018-2019_0.1m/rgb/2193/collection.json
@@ -2286,6 +2286,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2018-2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.8531345, -38.468168, 177.3035488, -37.3872422]] },
     "temporal": { "interval": [["2018-07-11T12:00:00Z", "2019-01-16T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2019_0.3m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2019_0.3m/rgb/2193/collection.json
@@ -85,6 +85,7 @@
     { "name": "BOPLASS", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[177.0823621, -38.280066, 178.082077, -37.5281811]] },
     "temporal": { "interval": [["2016-11-22T11:00:00Z", "2019-05-02T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2020_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2020_0.1m/rgb/2193/collection.json
@@ -4809,6 +4809,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2020_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.9812113, -37.8358253, 176.4738463, -37.6084886]] },
     "temporal": { "interval": [["2020-12-15T11:00:00Z", "2020-12-15T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2021-2022_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2021-2022_0.2m/rgb/2193/collection.json
@@ -6082,6 +6082,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2021-2022_0.2m",
   "extent": {
     "spatial": { "bbox": [[176.4620537, -38.8704907, 178.1159018, -37.5040892]] },
     "temporal": { "interval": [["2021-12-01T11:00:00Z", "2022-05-05T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2021_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2021_0.2m/rgb/2193/collection.json
@@ -4562,6 +4562,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2021_0.2m",
   "extent": {
     "spatial": { "bbox": [[175.7961839, -39.0220351, 176.7121709, -37.3607789]] },
     "temporal": { "interval": [["2021-01-30T11:00:00Z", "2021-04-02T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
@@ -394,6 +394,7 @@
   "linz:geospatial_category": "rural-aerial-photos",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
+  "linz:slug": "bay-of-plenty_2023-2024_0.2m",
   "extent": {
     "spatial": { "bbox": [[175.8730667, -38.1777928, 177.6669085, -37.3727916]] },
     "temporal": { "interval": [["2023-12-14T11:00:00Z", "2024-01-25T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2023_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2023_0.1m/rgb/2193/collection.json
@@ -2702,6 +2702,7 @@
     { "name": "BOPLASS", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "bay-of-plenty_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.8578196, -38.468168, 177.3140766, -37.3867045]] },
     "temporal": { "interval": [["2023-03-10T11:00:00Z", "2023-04-26T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2024_0.2m/rgb/2193/collection.json
@@ -35190,6 +35190,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-09-09T23:59:53Z",
   "updated": "2024-09-09T23:59:53Z",
+  "linz:slug": "bay-of-plenty_2024_0.2m",
   "extent": {
     "spatial": { "bbox": [[175.7735301, -39.0479419, 176.7459796, -37.3213498]] },
     "temporal": { "interval": [["2024-01-25T11:00:00Z", "2024-03-31T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_gisborne_sn5975_1981_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_gisborne_sn5975_1981_0.375m/rgb/2193/collection.json
@@ -352,6 +352,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_gisborne_sn5975_1981_0.375m",
   "extent": {
     "spatial": { "bbox": [[177.0425187, -38.0868341, 178.3039406, -37.7137308]] },
     "temporal": { "interval": [["1981-12-03T11:00:00Z", "1981-12-03T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_gisborne_sn8564_1985_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_gisborne_sn8564_1985_0.375m/rgb/2193/collection.json
@@ -219,6 +219,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_gisborne_sn8564_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[177.266121, -38.3702851, 177.8601152, -38.0245226]] },
     "temporal": { "interval": [["1985-11-15T11:00:00Z", "1985-11-15T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_hawkes-bay_sn8419_1984_0.75m/rgb/2193/collection.json
@@ -305,6 +305,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_hawkes-bay_sn8419_1984_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.3106639, -38.9556485, 177.5602111, -38.0396412]] },
     "temporal": { "interval": [["1984-11-20T11:00:00Z", "1984-12-25T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_sn8240_1983_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8240_1983_0.75m/rgb/2193/collection.json
@@ -113,6 +113,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_sn8240_1983_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.2389344, -38.1423603, 177.4609627, -37.6825823]] },
     "temporal": { "interval": [["1983-09-22T12:00:00Z", "1983-12-22T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_sn8540_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8540_1985-1986_0.375m/rgb/2193/collection.json
@@ -225,6 +225,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_sn8540_1985-1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[176.3483578, -38.4007006, 176.9526929, -38.0581835]] },
     "temporal": { "interval": [["1985-10-06T12:00:00Z", "1986-11-09T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_sn8626_1986_0.4m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8626_1986_0.4m/rgb/2193/collection.json
@@ -222,6 +222,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_sn8626_1986_0.4m",
   "extent": {
     "spatial": { "bbox": [[175.8693641, -37.8615848, 176.6000101, -37.2762505]] },
     "temporal": { "interval": [["1986-03-18T12:00:00Z", "1986-03-18T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_sn8732_1987_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8732_1987_0.15m/rgb/2193/collection.json
@@ -959,6 +959,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_sn8732_1987_0.15m",
   "extent": {
     "spatial": { "bbox": [[176.5846178, -38.1704688, 177.0998727, -37.8221129]] },
     "temporal": { "interval": [["1987-03-07T12:00:00Z", "1987-03-26T12:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_sn9383_1994_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn9383_1994_0.75m/rgb/2193/collection.json
@@ -84,6 +84,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_sn9383_1994_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.8583474, -37.9581258, 176.519877, -37.4355213]] },
     "temporal": { "interval": [["1994-11-27T11:00:00Z", "1994-11-28T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_snc25059_2001_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_snc25059_2001_0.75m/rgb/2193/collection.json
@@ -60,6 +60,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_snc25059_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.683288, -38.1291928, 177.4609627, -37.8612063]] },
     "temporal": { "interval": [["2001-01-03T11:00:00Z", "2001-01-03T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_snc30006a_2002_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_snc30006a_2002_0.75m/rgb/2193/collection.json
@@ -178,6 +178,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_snc30006a_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.3476384, -39.0391842, 176.9358418, -37.6825823]] },
     "temporal": { "interval": [["2002-03-05T11:00:00Z", "2002-03-05T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_snc50515_2003_0.625m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_snc50515_2003_0.625m/rgb/2193/collection.json
@@ -71,6 +71,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_snc50515_2003_0.625m",
   "extent": {
     "spatial": { "bbox": [[176.0812247, -38.341254, 176.4838055, -37.8137435]] },
     "temporal": { "interval": [["2003-12-18T11:00:00Z", "2003-12-18T11:00:00Z"]] }

--- a/stac/bay-of-plenty/bay-of-plenty_waikato_snc25058_2001_0.75m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_waikato_snc25058_2001_0.75m/rgb/2193/collection.json
@@ -127,6 +127,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "bay-of-plenty_waikato_snc25058_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.3646519, -37.9055931, 176.519877, -37.4989048]] },
     "temporal": { "interval": [["2001-02-01T11:00:00Z", "2001-02-01T11:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
@@ -3115,6 +3115,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tauranga-winter_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.056766, -37.7948242, 176.4270065, -37.6207199]] },
     "temporal": { "interval": [["2022-07-31T12:00:00Z", "2022-08-04T12:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
@@ -806,6 +806,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tauranga_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.031146, -37.8256149, 176.4215671, -37.6140937]] },
     "temporal": { "interval": [["2017-03-20T11:00:00Z", "2017-03-20T11:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
@@ -3180,6 +3180,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tauranga_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.056766, -37.7948242, 176.4270065, -37.6206467]] },
     "temporal": { "interval": [["2022-01-17T11:00:00Z", "2022-01-17T11:00:00Z"]] }

--- a/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
@@ -5342,6 +5342,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "ashburton_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0307368, -44.2077101, 172.0610351, -43.5904192]] },
     "temporal": { "interval": [["2020-01-15T11:00:00Z", "2020-01-16T11:00:00Z"]] }

--- a/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
@@ -3101,6 +3101,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "ashburton_2021-2022_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0367883, -44.1917843, 172.2051486, -43.5126799]] },
     "temporal": { "interval": [["2021-11-04T11:00:00Z", "2022-01-01T11:00:00Z"]] }

--- a/stac/canterbury/ashburton_2023-2024_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2023-2024_0.075m/rgb/2193/collection.json
@@ -18470,6 +18470,7 @@
   "created": "2024-08-05T08:52:52Z",
   "updated": "2024-08-05T08:52:52Z",
   "linz:geographic_description": "Ashburton",
+  "linz:slug": "ashburton_2023-2024_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0367883, -44.1917453, 172.1991728, -43.5126799]] },
     "temporal": { "interval": [["2023-12-19T11:00:00Z", "2024-02-13T11:00:00Z"]] }

--- a/stac/canterbury/ashburton_2023_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2023_0.1m/rgb/2193/collection.json
@@ -1675,6 +1675,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "ashburton_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[171.6752774, -43.977791, 171.8682778, -43.8505266]] },
     "temporal": { "interval": [["2023-02-27T11:00:00Z", "2023-04-03T12:00:00Z"]] }

--- a/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
@@ -1797,6 +1797,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "banks-peninsula_2019-2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.6746125, -43.844809, 173.1013881, -43.6340198]] },
     "temporal": { "interval": [["2019-12-27T11:00:00Z", "2020-03-21T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2012-2013_0.4m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2012-2013_0.4m/rgb/2193/collection.json
@@ -1472,6 +1472,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2012-2013_0.4m",
   "extent": {
     "spatial": { "bbox": [[170.7632508, -44.5643465, 172.7019786, -43.2130103]] },
     "temporal": { "interval": [["2012-10-29T11:00:00Z", "2013-03-27T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2013-2014_0.4m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2013-2014_0.4m/rgb/2193/collection.json
@@ -2085,6 +2085,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2013-2014_0.4m",
   "extent": {
     "spatial": { "bbox": [[169.4200673, -45.1001996, 171.2979602, -43.6074265]] },
     "temporal": { "interval": [["2013-10-28T11:00:00Z", "2014-03-26T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2014-2015_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2014-2015_0.3m/rgb/2193/collection.json
@@ -1679,6 +1679,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2014-2015_0.3m",
   "extent": {
     "spatial": { "bbox": [[171.7681974, -43.345188, 174.1575953, -41.8502007]] },
     "temporal": { "interval": [["2015-01-08T11:00:00Z", "2015-01-23T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2015-2016_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2015-2016_0.3m/rgb/2193/collection.json
@@ -1911,6 +1911,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2015-2016_0.3m",
   "extent": {
     "spatial": { "bbox": [[169.9589923, -43.9291124, 173.1491725, -42.7330106]] },
     "temporal": { "interval": [["2015-11-15T11:00:00Z", "2016-04-09T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2017-2018_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2017-2018_0.3m/rgb/2193/collection.json
@@ -2485,6 +2485,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2017-2018_0.3m",
   "extent": {
     "spatial": { "bbox": [[169.5626434, -45.5922567, 172.2234969, -43.4008818]] },
     "temporal": { "interval": [["2017-02-13T11:00:00Z", "2018-03-29T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2019_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2019_0.3m/rgb/2193/collection.json
@@ -745,6 +745,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[171.5446188, -43.9266718, 173.0297863, -42.8884091]] },
     "temporal": { "interval": [["2019-02-08T11:00:00Z", "2019-04-30T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2020-2021_0.2m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2020-2021_0.2m/rgb/2193/collection.json
@@ -1216,6 +1216,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2020-2021_0.2m",
   "extent": {
     "spatial": { "bbox": [[170.7716574, -44.5634189, 172.2836111, -43.1072316]] },
     "temporal": { "interval": [["2020-12-02T11:00:00Z", "2021-03-13T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2020_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2020_0.3m/rgb/2193/collection.json
@@ -699,6 +699,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2020_0.3m",
   "extent": {
     "spatial": { "bbox": [[171.8452721, -43.959082, 173.1492532, -43.0847955]] },
     "temporal": { "interval": [["2020-10-23T11:00:00Z", "2020-11-12T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2022_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2022_0.3m/rgb/2193/collection.json
@@ -2202,6 +2202,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2022_0.3m",
   "extent": {
     "spatial": { "bbox": [[170.2491649, -44.8868648, 174.0718765, -41.9141607]] },
     "temporal": { "interval": [["2021-12-31T11:00:00Z", "2022-03-30T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_2023_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2023_0.3m/rgb/2193/collection.json
@@ -187,6 +187,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "canterbury_2023_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.3429505, -43.9291124, 173.1491725, -43.5722488]] },
     "temporal": { "interval": [["2023-04-04T12:00:00Z", "2023-04-24T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_marlborough_sn8533_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_marlborough_sn8533_1985-1986_0.375m/rgb/2193/collection.json
@@ -438,6 +438,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_marlborough_sn8533_1985-1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.1459011, -42.7294675, 174.2996332, -41.5888381]] },
     "temporal": { "interval": [["1985-09-13T12:00:00Z", "1986-01-30T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_otago_sn8337_1984_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_otago_sn8337_1984_0.75m/rgb/2193/collection.json
@@ -63,6 +63,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_otago_sn8337_1984_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.5981956, -45.1120942, 171.2139114, -44.6576149]] },
     "temporal": { "interval": [["1984-02-23T11:00:00Z", "1984-12-02T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_otago_sn8568_1985-1987_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_otago_sn8568_1985-1987_0.75m/rgb/2193/collection.json
@@ -326,6 +326,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_otago_sn8568_1985-1987_0.75m",
   "extent": {
     "spatial": { "bbox": [[169.0380465, -44.6805634, 170.9319921, -43.9611416]] },
     "temporal": { "interval": [["1985-11-14T11:00:00Z", "1986-12-31T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn12542_1998_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn12542_1998_0.75m/rgb/2193/collection.json
@@ -148,6 +148,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn12542_1998_0.75m",
   "extent": {
     "spatial": { "bbox": [[171.7095773, -44.1493768, 172.3207666, -43.1765211]] },
     "temporal": { "interval": [["1998-09-28T12:00:00Z", "1998-09-28T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn12543_1998-1999_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn12543_1998-1999_0.75m/rgb/2193/collection.json
@@ -168,6 +168,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn12543_1998-1999_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.4907544, -44.6605991, 171.8321438, -43.9528807]] },
     "temporal": { "interval": [["1998-11-13T11:00:00Z", "1999-01-18T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn25022_2000_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn25022_2000_0.75m/rgb/2193/collection.json
@@ -85,6 +85,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn25022_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.1452292, -42.535092, 173.9022121, -42.1425875]] },
     "temporal": { "interval": [["2000-01-12T11:00:00Z", "2000-02-22T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn5204_1978_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn5204_1978_0.75m/rgb/2193/collection.json
@@ -169,6 +169,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn5204_1978_0.75m",
   "extent": {
     "spatial": { "bbox": [[171.1096531, -44.1493768, 172.3142003, -43.4924371]] },
     "temporal": { "interval": [["1978-02-14T11:00:00Z", "1978-02-14T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn5771_1980-1981_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn5771_1980-1981_0.375m/rgb/2193/collection.json
@@ -203,6 +203,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn5771_1980-1981_0.375m",
   "extent": {
     "spatial": { "bbox": [[170.6008895, -44.9192558, 171.1856737, -44.5860169]] },
     "temporal": { "interval": [["1980-10-05T12:00:00Z", "1981-02-20T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8261_1983_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8261_1983_0.75m/rgb/2193/collection.json
@@ -83,6 +83,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8261_1983_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.0516064, -44.9134241, 170.8532618, -44.5736346]] },
     "temporal": { "interval": [["1983-11-14T11:00:00Z", "1983-11-14T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8389_1984_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8389_1984_0.375m/rgb/2193/collection.json
@@ -495,6 +495,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8389_1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[172.1700408, -43.9291124, 173.1491725, -43.245407]] },
     "temporal": { "interval": [["1984-09-27T12:00:00Z", "1984-10-27T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8453_1985_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8453_1985_0.75m/rgb/2193/collection.json
@@ -287,6 +287,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8453_1985_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.0977879, -42.8592009, 173.9594288, -42.0772793]] },
     "temporal": { "interval": [["1985-01-17T11:00:00Z", "1985-01-27T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8532_1985_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8532_1985_0.375m/rgb/2193/collection.json
@@ -401,6 +401,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8532_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[171.6867401, -43.8298143, 172.3485707, -43.2410072]] },
     "temporal": { "interval": [["1985-09-13T12:00:00Z", "1985-11-13T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8569_1985-1986_0.8m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8569_1985-1986_0.8m/rgb/2193/collection.json
@@ -201,6 +201,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8569_1985-1986_0.8m",
   "extent": {
     "spatial": { "bbox": [[172.0855042, -43.3777572, 173.4402023, -42.6617195]] },
     "temporal": { "interval": [["1985-11-13T11:00:00Z", "1986-01-29T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8584_1986_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8584_1986_0.75m/rgb/2193/collection.json
@@ -298,6 +298,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8584_1986_0.75m",
   "extent": {
     "spatial": { "bbox": [[171.0685908, -43.6265174, 172.4429963, -42.5861331]] },
     "temporal": { "interval": [["1986-01-04T11:00:00Z", "1986-02-08T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8720_1987_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8720_1987_0.375m/rgb/2193/collection.json
@@ -464,6 +464,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8720_1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[170.6443976, -44.6884024, 171.7715977, -44.0354835]] },
     "temporal": { "interval": [["1987-02-21T11:00:00Z", "1987-04-10T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn8777_1987_0.375m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn8777_1987_0.375m/rgb/2193/collection.json
@@ -319,6 +319,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn8777_1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[171.1706336, -44.1166457, 172.3138297, -43.784978]] },
     "temporal": { "interval": [["1987-10-30T11:00:00Z", "1987-10-30T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn9381_1994_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn9381_1994_0.75m/rgb/2193/collection.json
@@ -142,6 +142,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn9381_1994_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.0746883, -43.959082, 172.8512291, -43.116356]] },
     "temporal": { "interval": [["1994-11-25T11:00:00Z", "1994-11-25T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_sn9447_1995_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_sn9447_1995_0.75m/rgb/2193/collection.json
@@ -66,6 +66,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_sn9447_1995_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.5536931, -43.9615254, 173.149415, -43.5070798]] },
     "temporal": { "interval": [["1995-09-18T12:00:00Z", "1995-12-09T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_snc25051_2000_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc25051_2000_0.75m/rgb/2193/collection.json
@@ -97,6 +97,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_snc25051_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.6184899, -42.7945432, 173.3815101, -42.4048728]] },
     "temporal": { "interval": [["2000-12-04T11:00:00Z", "2000-12-04T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_snc25053_2001_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc25053_2001_0.75m/rgb/2193/collection.json
@@ -135,6 +135,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_snc25053_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[171.0644365, -44.2105512, 171.9003745, -43.4295159]] },
     "temporal": { "interval": [["2001-02-09T11:00:00Z", "2001-02-27T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_snc25054_2000-2001_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc25054_2000-2001_0.75m/rgb/2193/collection.json
@@ -169,6 +169,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_snc25054_2000-2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.1931971, -43.8965118, 172.7941396, -42.8570302]] },
     "temporal": { "interval": [["2000-12-04T11:00:00Z", "2001-02-09T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_snc30000_2002_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc30000_2002_0.75m/rgb/2193/collection.json
@@ -91,6 +91,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_snc30000_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.1504557, -44.1361383, 170.8836041, -43.7319737]] },
     "temporal": { "interval": [["2002-01-20T11:00:00Z", "2002-01-20T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_snc30009_2003_0.75m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_snc30009_2003_0.75m/rgb/2193/collection.json
@@ -78,6 +78,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_snc30009_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.145676, -42.988966, 173.67147, -42.338698]] },
     "temporal": { "interval": [["2003-01-29T11:00:00Z", "2003-02-05T11:00:00Z"]] }

--- a/stac/canterbury/canterbury_west-coast_sn8595_1986-1987_0.96m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_west-coast_sn8595_1986-1987_0.96m/rgb/2193/collection.json
@@ -432,6 +432,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "canterbury_west-coast_sn8595_1986-1987_0.96m",
   "extent": {
     "spatial": { "bbox": [[168.6494863, -44.1721967, 171.4811629, -43.3449037]] },
     "temporal": { "interval": [["1986-01-31T11:00:00Z", "1987-02-14T11:00:00Z"]] }

--- a/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
@@ -1802,6 +1802,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] }
   ],
+  "linz:slug": "christchurch-earthquake_2011_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.4819524, -43.8253912, 172.9940331, -43.331846]] },
     "temporal": { "interval": [["2011-02-23T11:00:00Z", "2011-02-23T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
@@ -7011,6 +7011,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "christchurch_2015-2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3917526, -43.8350827, 173.1013443, -43.3877866]] },
     "temporal": { "interval": [["2016-01-21T11:00:00Z", "2016-02-19T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2018-2019_0.075m/rgb/2193/collection.json
@@ -8002,6 +8002,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "christchurch_2018-2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.377018, -43.6822941, 172.8364487, -43.3776766]] },
     "temporal": { "interval": [["2018-11-04T11:00:00Z", "2019-03-25T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2018_0.075m/rgb/2193/collection.json
@@ -116,6 +116,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "christchurch_2018_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.6108301, -43.5428598, 172.6525502, -43.5200356]] },
     "temporal": { "interval": [["2018-01-13T11:00:00Z", "2018-01-13T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2020-2021_0.075m/rgb/2193/collection.json
@@ -7309,6 +7309,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "christchurch_2020-2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3917851, -43.835085, 173.1043194, -43.3873534]] },
     "temporal": { "interval": [["2020-12-14T11:00:00Z", "2021-02-11T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2021_0.05m/rgb/2193/collection.json
@@ -113,6 +113,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "christchurch_2021_0.05m",
   "extent": {
     "spatial": { "bbox": [[172.6108301, -43.5428598, 172.6525502, -43.5200656]] },
     "temporal": { "interval": [["2021-02-10T11:00:00Z", "2021-02-11T11:00:00Z"]] }

--- a/stac/canterbury/christchurch_2023_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2023_0.075m/rgb/2193/collection.json
@@ -6872,6 +6872,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "christchurch_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3917851, -43.8350827, 173.0983689, -43.3873534]] },
     "temporal": { "interval": [["2023-01-15T11:00:00Z", "2023-04-04T12:00:00Z"]] }

--- a/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
@@ -301,6 +301,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hurunui_2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[172.7107171, -43.2059841, 172.7701423, -43.0471458]] },
     "temporal": { "interval": [["2013-02-23T11:00:00Z", "2013-02-23T11:00:00Z"]] }

--- a/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
@@ -2972,6 +2972,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hurunui_2018-2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.5743037, -43.2509575, 173.4971847, -42.4669882]] },
     "temporal": { "interval": [["2018-11-10T11:00:00Z", "2019-01-26T11:00:00Z"]] }

--- a/stac/canterbury/hurunui_2023_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2023_0.075m/rgb/2193/collection.json
@@ -773,6 +773,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hurunui_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.5831943, -43.2444432, 173.4797619, -42.4767226]] },
     "temporal": { "interval": [["2023-01-14T11:00:00Z", "2023-03-23T11:00:00Z"]] }

--- a/stac/canterbury/kaikoura-earthquake_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura-earthquake_2016-2017_0.3m/rgb/2193/collection.json
@@ -1665,6 +1665,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Aerial Surveys", "roles": ["producer"] }
   ],
+  "linz:slug": "kaikoura-earthquake_2016-2017_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.3526888, -43.2482147, 174.3009447, -41.458861]] },
     "temporal": { "interval": [["2016-12-19T11:00:00Z", "2017-02-23T11:00:00Z"]] }

--- a/stac/canterbury/kaikoura-earthquake_2016_0.2m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura-earthquake_2016_0.2m/rgb/2193/collection.json
@@ -604,6 +604,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "kaikoura-earthquake_2016_0.2m",
   "extent": {
     "spatial": { "bbox": [[173.2638486, -42.7358876, 173.9472199, -42.1616646]] },
     "temporal": { "interval": [["2016-11-13T11:00:00Z", "2016-11-13T11:00:00Z"]] }

--- a/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
@@ -656,6 +656,7 @@
   "created": "2024-08-05T08:51:58Z",
   "updated": "2024-08-05T08:51:58Z",
   "linz:geographic_description": "Kaikoura",
+  "linz:slug": "kaikoura_2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[173.6386994, -42.4261794, 173.7088714, -42.3710316]] },
     "temporal": { "interval": [["2023-12-14T11:00:00Z", "2023-12-14T11:00:00Z"]] }

--- a/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
@@ -2836,6 +2836,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "mackenzie_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[169.9177067, -44.2974718, 170.8928271, -43.9720456]] },
     "temporal": { "interval": [["2020-01-18T11:00:00Z", "2020-02-29T11:00:00Z"]] }

--- a/stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json
@@ -841,6 +841,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "mackenzie_2021_0.3m",
   "extent": {
     "spatial": { "bbox": [[169.5794922, -44.70234, 170.7954319, -43.6767732]] },
     "temporal": { "interval": [["2021-01-13T11:00:00Z", "2021-03-18T11:00:00Z"]] }

--- a/stac/canterbury/mackenzie_2023_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2023_0.075m/rgb/2193/collection.json
@@ -1470,6 +1470,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "mackenzie_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[169.9237123, -44.2901989, 170.884396, -43.981893]] },
     "temporal": { "interval": [["2023-01-18T11:00:00Z", "2023-03-22T11:00:00Z"]] }

--- a/stac/canterbury/port-hills-false-colour_2024_10m/rgb/2193/collection.json
+++ b/stac/canterbury/port-hills-false-colour_2024_10m/rgb/2193/collection.json
@@ -23,6 +23,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Port Hills False Colour",
+  "linz:slug": "port-hills-false-colour_2024_10m",
   "extent": {
     "spatial": { "bbox": [[172.5527303, -43.7669516, 172.8517065, -43.4420347]] },
     "temporal": { "interval": [["2024-02-17T11:00:00Z", "2024-02-17T11:00:00Z"]] }

--- a/stac/canterbury/port-hills_2024_10m/rgb/2193/collection.json
+++ b/stac/canterbury/port-hills_2024_10m/rgb/2193/collection.json
@@ -23,6 +23,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Port Hills",
+  "linz:slug": "port-hills_2024_10m",
   "extent": {
     "spatial": { "bbox": [[172.5527303, -43.7669516, 172.8517065, -43.4420347]] },
     "temporal": { "interval": [["2024-02-17T11:00:00Z", "2024-02-17T11:00:00Z"]] }

--- a/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
@@ -1988,6 +1988,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "selwyn_2012-2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[172.0616923, -43.8294982, 172.5741996, -43.4585793]] },
     "temporal": { "interval": [["2012-12-03T11:00:00Z", "2012-12-18T11:00:00Z"]] }

--- a/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
@@ -3706,6 +3706,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "selwyn_2018-2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.5188866, -43.8975024, 172.5683607, -43.1763563]] },
     "temporal": { "interval": [["2018-12-16T11:00:00Z", "2019-04-18T12:00:00Z"]] }

--- a/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
@@ -534,6 +534,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "selwyn_2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.5499206, -43.6007203, 172.5335176, -42.9248042]] },
     "temporal": { "interval": [["2019-12-26T11:00:00Z", "2019-12-27T11:00:00Z"]] }

--- a/stac/canterbury/selwyn_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2020-2021_0.075m/rgb/2193/collection.json
@@ -566,6 +566,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "selwyn_2020-2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3487529, -43.6588677, 172.5273473, -43.5091742]] },
     "temporal": { "interval": [["2020-12-02T11:00:00Z", "2021-01-21T11:00:00Z"]] }

--- a/stac/canterbury/selwyn_2022-2023_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2022-2023_0.075m/rgb/2193/collection.json
@@ -2194,6 +2194,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "selwyn_2022-2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.5247306, -43.8909614, 172.5565253, -42.9313601]] },
     "temporal": { "interval": [["2022-12-28T11:00:00Z", "2023-02-28T11:00:00Z"]] }

--- a/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
@@ -1987,6 +1987,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "timaru_2012-2013_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0995967, -44.5019645, 171.3136422, -44.0644391]] },
     "temporal": { "interval": [["2012-11-13T11:00:00Z", "2012-12-03T11:00:00Z"]] }

--- a/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
@@ -3011,6 +3011,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "timaru_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0873653, -44.5116828, 171.3346752, -43.8802784]] },
     "temporal": { "interval": [["2020-01-17T11:00:00Z", "2020-01-17T11:00:00Z"]] }

--- a/stac/canterbury/timaru_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2022-2023_0.1m/rgb/2193/collection.json
@@ -1194,6 +1194,7 @@
     { "name": "Environment Canterbury", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "timaru_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[171.1118256, -44.4986782, 171.3109157, -44.0676788]] },
     "temporal": { "interval": [["2022-12-28T11:00:00Z", "2023-03-01T11:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
@@ -1852,6 +1852,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimakariri_2013-2014_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.1477831, -43.4100443, 172.7308672, -43.2609631]] },
     "temporal": { "interval": [["2013-11-12T11:00:00Z", "2013-12-19T11:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
@@ -1134,6 +1134,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimakariri_2015-2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3518074, -43.3998127, 172.7100418, -43.2414248]] },
     "temporal": { "interval": [["2016-01-21T11:00:00Z", "2016-01-21T11:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
@@ -2455,6 +2455,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimakariri_2021_0.05m",
   "extent": {
     "spatial": { "bbox": [[172.144688, -43.4131444, 172.7367961, -43.2577293]] },
     "temporal": { "interval": [["2021-01-02T11:00:00Z", "2021-02-06T11:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2023_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2023_0.1m/rgb/2193/collection.json
@@ -864,6 +864,7 @@
     { "name": "Waimakariri District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimakariri_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.1416831, -43.4101301, 172.7397535, -43.2605315]] },
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-03-30T11:00:00Z"]] }

--- a/stac/canterbury/waimakariri_2024_0.25m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2024_0.25m/rgb/2193/collection.json
@@ -1765,6 +1765,7 @@
   "created": "2024-07-01T22:16:53Z",
   "updated": "2024-07-01T22:16:53Z",
   "linz:geographic_description": "Waimakariri",
+  "linz:slug": "waimakariri_2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[171.904478, -43.5069757, 172.7932703, -43.0846398]] },
     "temporal": { "interval": [["2024-03-06T11:00:00Z", "2024-03-07T11:00:00Z"]] }

--- a/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
@@ -479,6 +479,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimate_2018_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0731488, -44.9345133, 171.2092172, -44.5109698]] },
     "temporal": { "interval": [["2018-11-05T11:00:00Z", "2018-12-23T11:00:00Z"]] }

--- a/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
@@ -612,6 +612,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimate_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[170.9908094, -44.7652759, 171.1022373, -44.7024341]] },
     "temporal": { "interval": [["2020-01-17T11:00:00Z", "2020-01-17T11:00:00Z"]] }

--- a/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
@@ -1136,6 +1136,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waimate_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[170.4720658, -44.9377021, 171.2092172, -44.5109698]] },
     "temporal": { "interval": [["2021-11-30T11:00:00Z", "2021-11-30T11:00:00Z"]] }

--- a/stac/canterbury/waitaki_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waitaki_2020-2021_0.075m/rgb/2193/collection.json
@@ -1456,6 +1456,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waitaki_2020-2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[169.8422939, -45.4977508, 171.1020316, -44.2679207]] },
     "temporal": { "interval": [["2020-12-06T11:00:00Z", "2021-03-18T11:00:00Z"]] }

--- a/stac/canterbury/waitaki_2021_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/waitaki_2021_0.3m/rgb/2193/collection.json
@@ -951,6 +951,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waitaki_2021_0.3m",
   "extent": {
     "spatial": { "bbox": [[170.1407482, -45.6557846, 171.2099186, -44.2590364]] },
     "temporal": { "interval": [["2021-02-05T11:00:00Z", "2021-03-13T11:00:00Z"]] }

--- a/stac/canterbury/waitaki_2023-2024_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waitaki_2023-2024_0.075m/rgb/2193/collection.json
@@ -9188,6 +9188,7 @@
   "created": "2024-08-05T08:57:56Z",
   "updated": "2024-08-05T08:57:56Z",
   "linz:geographic_description": "Waitaki",
+  "linz:slug": "waitaki_2023-2024_0.075m",
   "extent": {
     "spatial": { "bbox": [[169.9540169, -45.4977508, 171.1020316, -44.4694063]] },
     "temporal": { "interval": [["2023-12-13T11:00:00Z", "2024-02-17T11:00:00Z"]] }

--- a/stac/gisborne/gisborne-cyclone-bola_sn11485_1988_0.4m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne-cyclone-bola_sn11485_1988_0.4m/rgb/2193/collection.json
@@ -7242,6 +7242,7 @@
   "linz:security_classification": "unclassified",
   "linz:event_name": "Cyclone Bola",
   "linz:geographic_description": "Gisborne Cyclone Bola",
+  "linz:slug": "gisborne-cyclone-bola_sn11485_1988_0.4m",
   "extent": {
     "spatial": { "bbox": [[177.2608718, -39.1163927, 178.5789163, -37.5198659]] },
     "temporal": { "interval": [["1988-03-21T12:00:00Z", "1988-06-22T12:00:00Z"]] }

--- a/stac/gisborne/gisborne-cyclone-gabrielle_2023_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne-cyclone-gabrielle_2023_0.2m/rgb/2193/collection.json
@@ -944,6 +944,7 @@
     { "name": "Gisborne District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne-cyclone-gabrielle_2023_0.2m",
   "extent": {
     "spatial": { "bbox": [[177.3869047, -38.9966205, 178.5542377, -37.4981772]] },
     "temporal": { "interval": [["2023-02-19T11:00:00Z", "2023-05-16T12:00:00Z"]] }

--- a/stac/gisborne/gisborne_2012-2013_0.4m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2012-2013_0.4m/rgb/2193/collection.json
@@ -1134,6 +1134,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne_2012-2013_0.4m",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9654417, 178.5542377, -37.5174346]] },
     "temporal": { "interval": [["2011-02-01T11:00:00Z", "2013-01-08T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2012_0.125m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2012_0.125m/rgb/2193/collection.json
@@ -167,6 +167,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne_2012_0.125m",
   "extent": {
     "spatial": { "bbox": [[177.5291684, -38.7592481, 178.4173207, -37.5830715]] },
     "temporal": { "interval": [["2012-01-04T11:00:00Z", "2012-03-14T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2017-2018_0.1m/rgb/2193/collection.json
@@ -1989,6 +1989,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.5284614, -38.7603087, 178.4177365, -37.5830296]] },
     "temporal": { "interval": [["2017-03-30T11:00:00Z", "2018-02-15T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2017-2019_0.3m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2017-2019_0.3m/rgb/2193/collection.json
@@ -1146,6 +1146,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne_2017-2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9966205, 178.5789163, -37.5174346]] },
     "temporal": { "interval": [["2017-12-11T11:00:00Z", "2019-10-27T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2021-2023_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2021-2023_0.2m/rgb/2193/collection.json
@@ -950,6 +950,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne_2021-2023_0.2m",
   "extent": {
     "spatial": { "bbox": [[177.1024377, -38.9977677, 178.6060113, -37.5174346]] },
     "temporal": { "interval": [["2021-12-17T11:00:00Z", "2023-02-08T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2022-2023_0.1m/rgb/2193/collection.json
@@ -1921,6 +1921,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "gisborne_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.8233049, -38.7603087, 178.4177365, -37.5830296]] },
     "temporal": { "interval": [["2022-02-14T11:00:00Z", "2023-02-06T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2023-2024_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023-2024_0.1m/rgb/2193/collection.json
@@ -25211,6 +25211,7 @@
   "linz:geospatial_category": "rural-aerial-photos",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2023-2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.1156421, -38.9760729, 178.5784308, -37.5284958]] },
     "temporal": { "interval": [["2023-10-31T11:00:00Z", "2024-01-29T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023-2024_0.2m/rgb/2193/collection.json
@@ -6832,6 +6832,7 @@
   "linz:geospatial_category": "rural-aerial-photos",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2023-2024_0.2m",
   "extent": {
     "spatial": { "bbox": [[177.1042804, -38.9966205, 178.5542377, -37.4981772]] },
     "temporal": { "interval": [["2023-02-19T11:00:00Z", "2024-03-16T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2023_0.075m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023_0.075m/rgb/2193/collection.json
@@ -1993,6 +1993,7 @@
   "linz:geospatial_category": "urban-aerial-photos",
   "linz:region": "gisborne",
   "linz:security_classification": "unclassified",
+  "linz:slug": "gisborne_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[177.5284614, -38.7603087, 178.4177365, -37.5830296]] },
     "temporal": { "interval": [["2023-12-16T11:00:00Z", "2023-12-17T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_bay-of-plenty_sn5766_1980_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_bay-of-plenty_sn5766_1980_0.375m/rgb/2193/collection.json
@@ -220,6 +220,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_bay-of-plenty_sn5766_1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[177.6315856, -37.8058544, 178.5789163, -37.5186533]] },
     "temporal": { "interval": [["1980-09-30T12:00:00Z", "1980-09-30T12:00:00Z"]] }

--- a/stac/gisborne/gisborne_sn12540_1998_0.75m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn12540_1998_0.75m/rgb/2193/collection.json
@@ -68,6 +68,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_sn12540_1998_0.75m",
   "extent": {
     "spatial": { "bbox": [[178.0754817, -38.1374155, 178.5813461, -37.4863429]] },
     "temporal": { "interval": [["1998-09-13T12:00:00Z", "1998-09-13T12:00:00Z"]] }

--- a/stac/gisborne/gisborne_sn8132_1982_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8132_1982_0.375m/rgb/2193/collection.json
@@ -481,6 +481,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_sn8132_1982_0.375m",
   "extent": {
     "spatial": { "bbox": [[177.7148675, -38.7726114, 178.3975377, -38.0020344]] },
     "temporal": { "interval": [["1982-11-13T11:00:00Z", "1982-12-14T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_sn8418_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8418_1984-1985_0.375m/rgb/2193/collection.json
@@ -412,6 +412,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_sn8418_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[177.2831733, -38.886882, 177.9986535, -38.2831566]] },
     "temporal": { "interval": [["1984-11-11T11:00:00Z", "1985-01-05T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_sn8538_1985_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8538_1985_0.375m/rgb/2193/collection.json
@@ -174,6 +174,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_sn8538_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[178.1677909, -38.0727943, 178.5789163, -37.5186533]] },
     "temporal": { "interval": [["1985-10-02T12:00:00Z", "1985-10-06T12:00:00Z"]] }

--- a/stac/gisborne/gisborne_sn8941_1988_0.15m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_sn8941_1988_0.15m/rgb/2193/collection.json
@@ -419,6 +419,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_sn8941_1988_0.15m",
   "extent": {
     "spatial": { "bbox": [[177.9297162, -38.5371419, 178.3258523, -38.1747202]] },
     "temporal": { "interval": [["1988-03-21T12:00:00Z", "1988-03-21T12:00:00Z"]] }

--- a/stac/gisborne/gisborne_snc25046_2000_0.75m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_snc25046_2000_0.75m/rgb/2193/collection.json
@@ -64,6 +64,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_snc25046_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[177.6536048, -38.8740743, 178.3167721, -38.4580277]] },
     "temporal": { "interval": [["2000-12-22T11:00:00Z", "2000-12-22T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_snc8309_1983_0.4m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_snc8309_1983_0.4m/rgb/2193/collection.json
@@ -126,6 +126,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "gisborne_snc8309_1983_0.4m",
   "extent": {
     "spatial": { "bbox": [[177.957434, -37.9518583, 178.3489898, -37.5820518]] },
     "temporal": { "interval": [["1983-12-22T11:00:00Z", "1983-12-22T11:00:00Z"]] }

--- a/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
@@ -413,6 +413,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "central-hawkes-bay_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.3125906, -40.4162834, 176.9333547, -39.8114584]] },
     "temporal": { "interval": [["2018-01-23T11:00:00Z", "2018-01-29T11:00:00Z"]] }

--- a/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
@@ -2779,6 +2779,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hastings-district_2014-2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.5960924, -39.866709, 177.0533949, -39.1229587]] },
     "temporal": { "interval": [["2014-01-04T11:00:00Z", "2015-01-04T11:00:00Z"]] }

--- a/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
@@ -852,6 +852,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hastings_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.6082676, -39.8337753, 177.0370161, -39.2828978]] },
     "temporal": { "interval": [["2018-01-24T11:00:00Z", "2018-01-30T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/rgb/2193/collection.json
@@ -6178,6 +6178,7 @@
     { "name": "SKYCAN", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hawkes-bay-cyclone-gabrielle_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.3097734, -40.0558183, 177.4773044, -38.8693573]] },
     "temporal": { "interval": [["2023-02-18T11:00:00Z", "2023-02-20T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2014-2015_0.3m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2014-2015_0.3m/rgb/2193/collection.json
@@ -2095,6 +2095,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hawkes-bay_2014-2015_0.3m",
   "extent": {
     "spatial": { "bbox": [[176.0232649, -40.4747693, 178.0260432, -38.5582246]] },
     "temporal": { "interval": [["2015-01-01T11:00:00Z", "2015-03-27T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2019-2020_0.3m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2019-2020_0.3m/rgb/2193/collection.json
@@ -2206,6 +2206,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hawkes-bay_2019-2020_0.3m",
   "extent": {
     "spatial": { "bbox": [[175.995564, -40.5071447, 178.0283496, -38.533055]] },
     "temporal": { "interval": [["2019-01-29T11:00:00Z", "2020-12-15T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2021-2022_0.3m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2021-2022_0.3m/rgb/2193/collection.json
@@ -1850,6 +1850,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hawkes-bay_2021-2022_0.3m",
   "extent": {
     "spatial": { "bbox": [[176.0358006, -40.4407184, 178.0237405, -38.5683905]] },
     "temporal": { "interval": [["2021-11-21T11:00:00Z", "2022-04-15T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2022_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2022_0.05m/rgb/2193/collection.json
@@ -504,6 +504,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hawkes-bay_2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[176.8275888, -39.560049, 176.9256871, -39.3992641]] },
     "temporal": { "interval": [["2021-12-31T11:00:00Z", "2022-01-21T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2022_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2022_0.1m/rgb/2193/collection.json
@@ -2156,6 +2156,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hawkes-bay_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.3122772, -40.4232862, 177.0370161, -39.2828978]] },
     "temporal": { "interval": [["2021-12-31T11:00:00Z", "2022-01-21T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2023-2024_0.125m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023-2024_0.125m/rgb/2193/collection.json
@@ -11028,6 +11028,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-09-25T02:06:42Z",
   "updated": "2024-09-25T02:06:42Z",
+  "linz:slug": "hawkes-bay_2023-2024_0.125m",
   "extent": {
     "spatial": { "bbox": [[176.0358006, -40.4415595, 178.0237405, -38.5683905]] },
     "temporal": { "interval": [["2023-09-19T12:00:00Z", "2024-04-26T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_2023-2024_0.25m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023-2024_0.25m/rgb/2193/collection.json
@@ -11706,6 +11706,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-15T21:28:44Z",
   "updated": "2024-10-15T21:28:44Z",
+  "linz:slug": "hawkes-bay_2023-2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[176.0343987, -40.4678951, 178.0260432, -38.5360339]] },
     "temporal": { "interval": [["2023-11-12T11:00:00Z", "2024-04-17T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_bay-of-plenty_snc50516_2004_0.75m/rgb/2193/collection.json
@@ -73,6 +73,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_bay-of-plenty_snc50516_2004_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.1226657, -39.3082977, 176.5346629, -38.72693]] },
     "temporal": { "interval": [["2004-01-09T11:00:00Z", "2004-01-09T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m/rgb/2193/collection.json
@@ -711,6 +711,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_manawatu-whanganui_sn5752_1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.4724701, -39.7414671, 177.1129079, -39.1414598]] },
     "temporal": { "interval": [["1980-08-18T12:00:00Z", "1980-10-24T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m/rgb/2193/collection.json
@@ -639,6 +639,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_manawatu-whanganui_sn5761_1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.9436735, -40.291405, 177.0869065, -39.6743827]] },
     "temporal": { "interval": [["1980-09-22T12:00:00Z", "1980-10-24T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m/rgb/2193/collection.json
@@ -134,6 +134,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_manawatu-whanganui_snc30001_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.9258864, -39.7738609, 177.116758, -39.3556035]] },
     "temporal": { "interval": [["2002-01-20T11:00:00Z", "2002-01-20T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn7786_1989_0.48m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn7786_1989_0.48m/rgb/2193/collection.json
@@ -125,6 +125,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn7786_1989_0.48m",
   "extent": {
     "spatial": { "bbox": [[176.2281756, -40.1218555, 176.5711797, -39.7250885]] },
     "temporal": { "interval": [["1989-09-23T12:00:00Z", "1989-09-23T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn8675_1986_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn8675_1986_0.375m/rgb/2193/collection.json
@@ -130,6 +130,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn8675_1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[176.5511007, -39.7513388, 176.9993834, -39.3889029]] },
     "temporal": { "interval": [["1986-10-16T12:00:00Z", "1986-10-22T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn8985_1988_0.4m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn8985_1988_0.4m/rgb/2193/collection.json
@@ -400,6 +400,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn8985_1988_0.4m",
   "extent": {
     "spatial": { "bbox": [[176.3926078, -39.7276098, 177.1398598, -39.1213957]] },
     "temporal": { "interval": [["1988-11-25T11:00:00Z", "1988-12-08T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn9037_1989_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9037_1989_0.75m/rgb/2193/collection.json
@@ -58,6 +58,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn9037_1989_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.2281756, -40.1534387, 176.6307507, -39.6918603]] },
     "temporal": { "interval": [["1989-10-16T11:00:00Z", "1989-10-16T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn9410_1995_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9410_1995_0.375m/rgb/2193/collection.json
@@ -330,6 +330,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn9410_1995_0.375m",
   "extent": {
     "spatial": { "bbox": [[176.3077249, -40.5054656, 177.1129079, -39.5811851]] },
     "temporal": { "interval": [["1995-03-14T11:00:00Z", "1995-03-24T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn9452_1995_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9452_1995_0.375m/rgb/2193/collection.json
@@ -548,6 +548,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn9452_1995_0.375m",
   "extent": {
     "spatial": { "bbox": [[176.7742354, -39.390757, 178.0237405, -38.5582246]] },
     "temporal": { "interval": [["1995-10-17T11:00:00Z", "1995-11-07T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn9485_1995-1996_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9485_1995-1996_0.375m/rgb/2193/collection.json
@@ -905,6 +905,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn9485_1995-1996_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.9562084, -40.413282, 177.0750813, -38.9330055]] },
     "temporal": { "interval": [["1995-12-26T11:00:00Z", "1996-03-12T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_sn9585_1996_0.8m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9585_1996_0.8m/rgb/2193/collection.json
@@ -156,6 +156,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_sn9585_1996_0.8m",
   "extent": {
     "spatial": { "bbox": [[176.3710607, -40.0206673, 177.193365, -39.0223533]] },
     "temporal": { "interval": [["1996-12-11T11:00:00Z", "1996-12-16T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_snc50126_2003_0.6m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50126_2003_0.6m/rgb/2193/collection.json
@@ -177,6 +177,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_snc50126_2003_0.6m",
   "extent": {
     "spatial": { "bbox": [[176.7846589, -39.3221655, 178.0283496, -38.5571727]] },
     "temporal": { "interval": [["2003-01-15T11:00:00Z", "2003-01-30T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_snc50450_2004_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50450_2004_0.75m/rgb/2193/collection.json
@@ -133,6 +133,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_snc50450_2004_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.3434009, -39.3066748, 177.193365, -38.7026787]] },
     "temporal": { "interval": [["2004-12-06T11:00:00Z", "2004-12-06T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_snc50518_2004_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50518_2004_0.75m/rgb/2193/collection.json
@@ -73,6 +73,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_snc50518_2004_0.75m",
   "extent": {
     "spatial": { "bbox": [[176.1369294, -39.635319, 176.5511007, -39.1090812]] },
     "temporal": { "interval": [["2004-04-09T12:00:00Z", "2004-04-09T12:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_snc50519_2004_0.64m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50519_2004_0.64m/rgb/2193/collection.json
@@ -72,6 +72,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_snc50519_2004_0.64m",
   "extent": {
     "spatial": { "bbox": [[176.4140923, -39.6304745, 176.8265822, -39.1003652]] },
     "temporal": { "interval": [["2004-01-09T11:00:00Z", "2004-01-09T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_snc50520_2004_0.64m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc50520_2004_0.64m/rgb/2193/collection.json
@@ -64,6 +64,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_snc50520_2004_0.64m",
   "extent": {
     "spatial": { "bbox": [[176.6911433, -39.6218649, 177.0900659, -39.0262766]] },
     "temporal": { "interval": [["2004-01-09T11:00:00Z", "2004-01-09T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_snc8912_1987_0.375m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_snc8912_1987_0.375m/rgb/2193/collection.json
@@ -83,6 +83,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_snc8912_1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[176.4695118, -39.1755064, 176.9385834, -38.9770301]] },
     "temporal": { "interval": [["1987-12-28T11:00:00Z", "1987-12-28T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay_waikato_sn8260_1983_0.75m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_waikato_sn8260_1983_0.75m/rgb/2193/collection.json
@@ -284,6 +284,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "hawkes-bay_waikato_sn8260_1983_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.7939777, -39.3221655, 178.0283496, -38.5893311]] },
     "temporal": { "interval": [["1983-11-15T11:00:00Z", "1983-11-15T11:00:00Z"]] }

--- a/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
@@ -199,6 +199,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "napier_2017-2018_0.05m",
   "extent": {
     "spatial": { "bbox": [[176.8095037, -39.5571074, 176.9239961, -39.4760956]] },
     "temporal": { "interval": [["2018-01-19T11:00:00Z", "2018-01-29T11:00:00Z"]] }

--- a/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
@@ -1459,6 +1459,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "napier_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.8094564, -39.5743998, 176.927647, -39.3865041]] },
     "temporal": { "interval": [["2018-01-24T11:00:00Z", "2018-01-30T11:00:00Z"]] }

--- a/stac/hawkes-bay/wairoa-flood_2024_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa-flood_2024_0.1m/rgb/2193/collection.json
@@ -188,6 +188,7 @@
   "updated": "2024-07-11T02:44:27Z",
   "linz:event_name": "Wairoa Flood",
   "linz:geographic_description": "Wairoa Flood",
+  "linz:slug": "wairoa-flood_2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.3760874, -39.0801355, 177.4653969, -39.0129331]] },
     "temporal": { "interval": [["2024-07-09T12:00:00Z", "2024-07-09T12:00:00Z"]] }

--- a/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
@@ -532,6 +532,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wairoa_2014-2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.0112687, -39.132953, 177.9444863, -38.7907713]] },
     "temporal": { "interval": [["2014-12-21T11:00:00Z", "2015-12-21T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2015-2016_0.3m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2015-2016_0.3m/rgb/2193/collection.json
@@ -2033,6 +2033,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "manawatu-whanganui_2015-2016_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.9369198, -40.8034341, 176.6533676, -39.0347065]] },
     "temporal": { "interval": [["2015-12-26T11:00:00Z", "2016-04-20T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2016-2017_0.3m/rgb/2193/collection.json
@@ -999,6 +999,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "manawatu-whanganui_2016-2017_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.6649364, -39.989084, 175.6883336, -38.4532011]] },
     "temporal": { "interval": [["2016-03-10T11:00:00Z", "2017-04-07T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2021-2022_0.3m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2021-2022_0.3m/rgb/2193/collection.json
@@ -2934,6 +2934,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "manawatu-whanganui_2021-2022_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.6649364, -40.8034341, 176.681633, -38.4532011]] },
     "temporal": { "interval": [["2021-01-26T11:00:00Z", "2022-07-03T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2023-2024_0.2m/rgb/2193/collection.json
@@ -2410,6 +2410,7 @@
   "linz:geospatial_category": "rural-aerial-photos",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
+  "linz:slug": "manawatu-whanganui_2023-2024_0.2m",
   "extent": {
     "spatial": { "bbox": [[175.5661071, -40.7448334, 176.6533676, -39.738576]] },
     "temporal": { "interval": [["2023-12-20T11:00:00Z", "2024-03-09T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2024_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2024_0.125m/rgb/2193/collection.json
@@ -7852,6 +7852,7 @@
   "linz:geospatial_category": "rural-aerial-photos",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
+  "linz:slug": "manawatu-whanganui_2024_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.4766374, -40.1074229, 176.1423073, -39.7248805]] },
     "temporal": { "interval": [["2024-02-14T11:00:00Z", "2024-03-09T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m/rgb/2193/collection.json
@@ -263,6 +263,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_hawkes-bay_sn12541_1999_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.3823649, -40.3040369, 176.964008, -39.6236403]] },
     "temporal": { "interval": [["1999-01-26T11:00:00Z", "1999-04-21T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m/rgb/2193/collection.json
@@ -75,6 +75,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_hawkes-bay_snc50517_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.8596635, -39.6456847, 176.2719331, -39.1171402]] },
     "temporal": { "interval": [["2003-12-18T11:00:00Z", "2003-12-18T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn25017_2000_0.64m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn25017_2000_0.64m/rgb/2193/collection.json
@@ -103,6 +103,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn25017_2000_0.64m",
   "extent": {
     "spatial": { "bbox": [[175.4158466, -39.5887123, 176.1543519, -39.0583238]] },
     "temporal": { "interval": [["2000-02-23T11:00:00Z", "2000-02-23T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn5291_1978_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn5291_1978_0.375m/rgb/2193/collection.json
@@ -357,6 +357,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn5291_1978_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.0367177, -39.7607154, 176.1043793, -39.4463193]] },
     "temporal": { "interval": [["1978-10-28T12:00:00Z", "1978-10-28T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn5408_1979-1980_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn5408_1979-1980_0.375m/rgb/2193/collection.json
@@ -354,6 +354,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn5408_1979-1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.1799479, -40.5689633, 176.1443832, -40.1905127]] },
     "temporal": { "interval": [["1979-04-16T12:00:00Z", "1980-04-21T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8005_1982_0.8m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8005_1982_0.8m/rgb/2193/collection.json
@@ -151,6 +151,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn8005_1982_0.8m",
   "extent": {
     "spatial": { "bbox": [[174.42845, -40.3096888, 175.7390422, -39.7145259]] },
     "temporal": { "interval": [["1982-02-03T11:00:00Z", "1982-02-03T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8158_1983_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8158_1983_0.4m/rgb/2193/collection.json
@@ -228,6 +228,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn8158_1983_0.4m",
   "extent": {
     "spatial": { "bbox": [[175.5038062, -40.3022072, 176.1308537, -39.9645593]] },
     "temporal": { "interval": [["1983-01-01T11:00:00Z", "1983-03-17T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8303_1984_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8303_1984_0.375m/rgb/2193/collection.json
@@ -227,6 +227,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn8303_1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.0282698, -39.5013816, 175.6233294, -39.166204]] },
     "temporal": { "interval": [["1984-01-14T11:00:00Z", "1984-04-11T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn8316_1984_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn8316_1984_0.4m/rgb/2193/collection.json
@@ -230,6 +230,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn8316_1984_0.4m",
   "extent": {
     "spatial": { "bbox": [[175.4932085, -40.0429875, 176.1204664, -39.7054465]] },
     "temporal": { "interval": [["1984-01-31T11:00:00Z", "1984-04-10T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn9158_1991_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn9158_1991_0.375m/rgb/2193/collection.json
@@ -73,6 +73,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn9158_1991_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.6379485, -39.3442385, 174.9207266, -39.0840068]] },
     "temporal": { "interval": [["1991-03-31T12:00:00Z", "1991-03-31T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn9364_1994_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn9364_1994_0.375m/rgb/2193/collection.json
@@ -43,6 +43,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn9364_1994_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.4990788, -39.3624715, 175.6184709, -39.1331787]] },
     "temporal": { "interval": [["1994-07-03T12:00:00Z", "1994-07-03T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_sn9470_1995-1996_0.8m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_sn9470_1995-1996_0.8m/rgb/2193/collection.json
@@ -195,6 +195,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_sn9470_1995-1996_0.8m",
   "extent": {
     "spatial": { "bbox": [[175.1264348, -40.6890938, 176.8101383, -40.1379015]] },
     "temporal": { "interval": [["1995-11-21T11:00:00Z", "1996-09-02T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc12781_2003_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc12781_2003_0.75m/rgb/2193/collection.json
@@ -96,6 +96,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_snc12781_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.427019, -39.7855508, 176.1661558, -39.3793044]] },
     "temporal": { "interval": [["2003-03-20T12:00:00Z", "2003-03-20T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc25045_2001_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc25045_2001_0.75m/rgb/2193/collection.json
@@ -110,6 +110,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_snc25045_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.5404486, -40.3096888, 175.7312252, -39.7252198]] },
     "temporal": { "interval": [["2001-01-22T11:00:00Z", "2001-02-20T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc25061_2001_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc25061_2001_0.75m/rgb/2193/collection.json
@@ -128,6 +128,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_snc25061_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.1264348, -40.6348398, 176.2055911, -40.2213594]] },
     "temporal": { "interval": [["2001-02-20T11:00:00Z", "2001-02-20T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc8650_1986_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc8650_1986_0.375m/rgb/2193/collection.json
@@ -252,6 +252,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_snc8650_1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.9369198, -40.0524505, 175.6418308, -39.7170908]] },
     "temporal": { "interval": [["1986-03-07T12:00:00Z", "1986-03-07T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_snc8914_1988_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_snc8914_1988_0.375m/rgb/2193/collection.json
@@ -85,6 +85,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_snc8914_1988_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.0229933, -40.0838523, 175.4149103, -39.7570948]] },
     "temporal": { "interval": [["1988-01-05T11:00:00Z", "1988-01-15T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8004_1982_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8004_1982_0.75m/rgb/2193/collection.json
@@ -141,6 +141,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_taranaki_sn8004_1982_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.5332868, -39.8009312, 175.7132782, -39.3917926]] },
     "temporal": { "interval": [["1982-02-03T11:00:00Z", "1982-02-03T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8157_1983_0.8m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8157_1983_0.8m/rgb/2193/collection.json
@@ -136,6 +136,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_taranaki_sn8157_1983_0.8m",
   "extent": {
     "spatial": { "bbox": [[174.4114025, -39.0240813, 175.630559, -38.6140357]] },
     "temporal": { "interval": [["1983-01-01T11:00:00Z", "1983-03-04T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8549_1985_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8549_1985_0.375m/rgb/2193/collection.json
@@ -453,6 +453,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_taranaki_sn8549_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.5504357, -39.5087297, 175.1731047, -38.6240872]] },
     "temporal": { "interval": [["1985-10-28T11:00:00Z", "1985-10-29T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m/rgb/2193/collection.json
@@ -201,6 +201,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_taranaki_sn8686_1986-1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.5483228, -38.9574609, 175.1324965, -38.6565077]] },
     "temporal": { "interval": [["1986-11-19T11:00:00Z", "1987-02-08T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_waikato_sn8440_1984-1985_0.375m/rgb/2193/collection.json
@@ -398,6 +398,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_waikato_sn8440_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.9950131, -39.242035, 176.0814842, -38.8956266]] },
     "temporal": { "interval": [["1984-12-25T11:00:00Z", "1985-01-29T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn5310_1978-1979_0.375m/rgb/2193/collection.json
@@ -388,6 +388,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_wellington_sn5310_1978-1979_0.375m",
   "extent": {
     "spatial": { "bbox": [[176.0463508, -41.0995512, 176.7538074, -40.1721017]] },
     "temporal": { "interval": [["1978-11-29T11:00:00Z", "1979-02-20T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9284_1993_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9284_1993_0.75m/rgb/2193/collection.json
@@ -61,6 +61,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_wellington_sn9284_1993_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.0189523, -40.9599663, 175.4687695, -40.370032]] },
     "temporal": { "interval": [["1993-03-09T11:00:00Z", "1993-03-09T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9911_2000_0.75m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_wellington_sn9911_2000_0.75m/rgb/2193/collection.json
@@ -83,6 +83,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "manawatu-whanganui_wellington_sn9911_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.0189523, -40.8961623, 175.7060484, -40.4934044]] },
     "temporal": { "interval": [["2000-03-09T11:00:00Z", "2000-03-10T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
@@ -1315,6 +1315,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "manawatu_2019_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.2073285, -40.3997924, 175.8257914, -40.0370455]] },
     "temporal": { "interval": [["2019-01-28T11:00:00Z", "2019-02-02T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/manawatu_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2022-2023_0.1m/rgb/2193/collection.json
@@ -1444,6 +1444,7 @@
     { "name": "Manawatū District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "manawatu_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.2127585, -40.4126476, 175.8316951, -40.0043777]] },
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-03-30T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
@@ -534,6 +534,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "palmerston-north_2012-2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5386, -40.4245794, 175.7734202, -40.2711092]] },
     "temporal": { "interval": [["2012-12-19T11:00:00Z", "2012-12-19T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2014_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2014_0.4m/rgb/2193/collection.json
@@ -188,6 +188,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "palmerston-north_2014_0.4m",
   "extent": {
     "spatial": { "bbox": [[175.3508142, -40.6242996, 175.9096578, -40.1970916]] },
     "temporal": { "interval": [["2014-01-27T11:00:00Z", "2016-01-14T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
@@ -1039,6 +1039,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "palmerston-north_2015_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5101158, -40.4443971, 175.7959889, -40.2385783]] },
     "temporal": { "interval": [["2015-02-11T11:00:00Z", "2015-02-17T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
@@ -1064,6 +1064,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "palmerston-north_2017_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5103564, -40.4506255, 175.7959889, -40.2383077]] },
     "temporal": { "interval": [["2017-02-28T11:00:00Z", "2017-04-09T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
@@ -1092,6 +1092,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "palmerston-north_2018_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5105971, -40.468661, 175.8008276, -40.2414826]] },
     "temporal": { "interval": [["2018-12-08T11:00:00Z", "2018-12-08T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
@@ -1082,6 +1082,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "palmerston-north_2022_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5105971, -40.4685317, 175.80056, -40.2416114]] },
     "temporal": { "interval": [["2022-02-28T11:00:00Z", "2022-02-28T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/palmerston-north_2024_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2024_0.1m/rgb/2193/collection.json
@@ -5071,6 +5071,7 @@
   "created": "2024-06-19T01:55:07Z",
   "updated": "2024-06-19T01:55:07Z",
   "linz:geographic_description": "Palmerston North",
+  "linz:slug": "palmerston-north_2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.5324659, -40.4488335, 175.7795942, -40.2643597]] },
     "temporal": { "interval": [["2024-02-14T11:00:00Z", "2024-04-28T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
@@ -969,6 +969,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "rangitikei_2021_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.1108251, -40.3149861, 175.86285, -39.628026]] },
     "temporal": { "interval": [["2020-08-31T12:00:00Z", "2021-04-29T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/tararua_2024_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/tararua_2024_0.1m/rgb/2193/collection.json
@@ -556,6 +556,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Tararua",
+  "linz:slug": "tararua_2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.6788062, -40.6752192, 176.5749061, -40.0578804]] },
     "temporal": { "interval": [["2024-02-03T11:00:00Z", "2024-02-04T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
@@ -1781,6 +1781,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "whanganui_2013_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.9256066, -39.9878699, 175.1229765, -39.8664782]] },
     "temporal": { "interval": [["2013-01-29T11:00:00Z", "2013-02-06T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
@@ -709,6 +709,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "whanganui_2015-2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.8800975, -39.9944022, 175.143911, -39.8433772]] },
     "temporal": { "interval": [["2015-08-26T12:00:00Z", "2015-08-26T12:00:00Z"]] }

--- a/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
@@ -782,6 +782,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "whanganui_2017_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8744881, -39.9946971, 175.1495196, -39.8433772]] },
     "temporal": { "interval": [["2017-11-14T11:00:00Z", "2017-11-14T11:00:00Z"]] }

--- a/stac/manawatu-whanganui/whanganui_2022_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2022_0.075m/rgb/2193/collection.json
@@ -914,6 +914,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "whanganui_2022_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8800975, -39.9879192, 175.2199595, -39.8562391]] },
     "temporal": { "interval": [["2022-12-26T11:00:00Z", "2022-12-26T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2005_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2005_0.75m/rgb/2193/collection.json
@@ -481,6 +481,7 @@
     { "name": "Terralink International Ltd", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2005_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.0864788, -42.2108741, 174.1811647, -41.462174]] },
     "temporal": { "interval": [["2004-12-31T11:00:00Z", "2005-12-30T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2008_0.4m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2008_0.4m/rgb/2193/collection.json
@@ -949,6 +949,7 @@
     { "name": "Terralink International Ltd", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2008_0.4m",
   "extent": {
     "spatial": { "bbox": [[172.9364353, -41.8689874, 174.1967712, -41.1671341]] },
     "temporal": { "interval": [["2008-01-01T11:00:00Z", "2008-02-20T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2015-2016_0.2m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2015-2016_0.2m/rgb/2193/collection.json
@@ -5120,6 +5120,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2015-2016_0.2m",
   "extent": {
     "spatial": { "bbox": [[172.7272484, -42.3925132, 174.2874354, -41.388951]] },
     "temporal": { "interval": [["2016-01-06T11:00:00Z", "2016-03-06T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2017-2018_0.3m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2017-2018_0.3m/rgb/2193/collection.json
@@ -4104,6 +4104,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-20T21:23:26Z",
   "updated": "2024-10-20T21:23:26Z",
+  "linz:slug": "marlborough_2017-2018_0.3m",
   "extent": {
     "spatial": { "bbox": [[173.0287974, -41.6921453, 174.4582684, -40.6499379]] },
     "temporal": { "interval": [["2017-12-01T11:00:00Z", "2018-03-10T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2017_0.1m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2017_0.1m/rgb/2193/collection.json
@@ -3055,6 +3055,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.4980367, -41.8456407, 174.1647442, -41.0475327]] },
     "temporal": { "interval": [["2017-11-30T11:00:00Z", "2017-12-19T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2020-2021_0.1m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2020-2021_0.1m/rgb/2193/collection.json
@@ -5377,6 +5377,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2020-2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.4951828, -41.8521245, 174.167516, -41.0443091]] },
     "temporal": { "interval": [["2020-10-15T11:00:00Z", "2021-01-14T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2021-2022_0.25m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2021-2022_0.25m/rgb/2193/collection.json
@@ -5957,6 +5957,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2021-2022_0.25m",
   "extent": {
     "spatial": { "bbox": [[172.7152358, -42.4962761, 174.3107865, -41.3636282]] },
     "temporal": { "interval": [["2021-11-07T11:00:00Z", "2022-01-29T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
@@ -3502,6 +3502,7 @@
     { "name": "Marlborough District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "marlborough_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.5122766, -41.8391007, 174.1619132, -41.0474557]] },
     "temporal": { "interval": [["2023-10-22T11:00:00Z", "2023-11-22T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_2023_0.25m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.25m/rgb/2193/collection.json
@@ -21438,6 +21438,7 @@
   "linz:security_classification": "unclassified",
   "created": "2023-08-08T00:00:00Z",
   "updated": "2024-10-02T22:18:27Z",
+  "linz:slug": "marlborough_2023_0.25m",
   "extent": {
     "spatial": { "bbox": [[173.0057635, -41.6921534, 174.4466921, -40.649988]] },
     "temporal": { "interval": [["2023-01-19T11:00:00Z", "2024-09-10T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn5100_1977_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn5100_1977_0.75m/rgb/2193/collection.json
@@ -51,6 +51,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn5100_1977_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.7117757, -41.0414153, 174.1135746, -40.6496832]] },
     "temporal": { "interval": [["1977-03-20T12:00:00Z", "1977-10-19T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn5638_1979-1980_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn5638_1979-1980_0.375m/rgb/2193/collection.json
@@ -207,6 +207,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn5638_1979-1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.4856783, -41.4617432, 174.4010981, -40.8755646]] },
     "temporal": { "interval": [["1979-12-20T11:00:00Z", "1980-09-19T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn8000_1982_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8000_1982_0.75m/rgb/2193/collection.json
@@ -180,6 +180,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn8000_1982_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.0860913, -42.0129092, 174.3002884, -41.3000536]] },
     "temporal": { "interval": [["1982-01-29T11:00:00Z", "1982-02-15T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn8049_1982_0.8m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8049_1982_0.8m/rgb/2193/collection.json
@@ -52,6 +52,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn8049_1982_0.8m",
   "extent": {
     "spatial": { "bbox": [[173.7202686, -41.8836651, 174.24126, -41.491579]] },
     "temporal": { "interval": [["1982-01-29T11:00:00Z", "1982-01-29T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn8200_1983_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8200_1983_0.375m/rgb/2193/collection.json
@@ -183,6 +183,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn8200_1983_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.6335245, -41.6904264, 174.18235, -41.3627452]] },
     "temporal": { "interval": [["1983-03-06T12:00:00Z", "1983-03-06T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn8262_1983_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn8262_1983_0.375m/rgb/2193/collection.json
@@ -360,6 +360,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn8262_1983_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.1719264, -41.4002097, 174.4024801, -41.069809]] },
     "temporal": { "interval": [["1983-11-19T11:00:00Z", "1983-12-04T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn9360_1994_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn9360_1994_0.75m/rgb/2193/collection.json
@@ -126,6 +126,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn9360_1994_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.6014303, -41.4957188, 174.2912123, -40.6496832]] },
     "temporal": { "interval": [["1994-04-26T12:00:00Z", "1994-04-27T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn9471_1995_0.8m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn9471_1995_0.8m/rgb/2193/collection.json
@@ -47,6 +47,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn9471_1995_0.8m",
   "extent": {
     "spatial": { "bbox": [[174.1113957, -41.3624698, 174.458987, -40.9079881]] },
     "temporal": { "interval": [["1995-11-22T11:00:00Z", "1995-11-22T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_sn9586_1996_0.32m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_sn9586_1996_0.32m/rgb/2193/collection.json
@@ -141,6 +141,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_sn9586_1996_0.32m",
   "extent": {
     "spatial": { "bbox": [[173.6044271, -41.6904264, 174.1512089, -41.3627452]] },
     "temporal": { "interval": [["1996-12-15T11:00:00Z", "1996-12-15T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_snc25048_2000_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc25048_2000_0.75m/rgb/2193/collection.json
@@ -70,6 +70,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_snc25048_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.5463195, -41.6908715, 174.18235, -41.3624698]] },
     "temporal": { "interval": [["2000-12-03T11:00:00Z", "2000-12-03T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_snc2887_1975_0.3m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc2887_1975_0.3m/rgb/2193/collection.json
@@ -76,6 +76,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_snc2887_1975_0.3m",
   "extent": {
     "spatial": { "bbox": [[173.7502057, -41.8192295, 174.18235, -41.5564186]] },
     "temporal": { "interval": [["1975-10-28T11:00:00Z", "1975-10-28T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_snc30007_2002_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc30007_2002_0.75m/rgb/2193/collection.json
@@ -67,6 +67,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_snc30007_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.143628, -41.6920874, 173.8363392, -41.4297503]] },
     "temporal": { "interval": [["2002-04-09T12:00:00Z", "2002-04-09T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_snc8294_1983_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_snc8294_1983_0.375m/rgb/2193/collection.json
@@ -208,6 +208,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_snc8294_1983_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.1435566, -41.5622428, 173.8608664, -41.1069211]] },
     "temporal": { "interval": [["1983-11-19T11:00:00Z", "1983-11-19T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_tasman_canterbury_sn8452_1985_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_tasman_canterbury_sn8452_1985_0.75m/rgb/2193/collection.json
@@ -223,6 +223,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_tasman_canterbury_sn8452_1985_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.0987112, -42.2758078, 174.1871302, -41.7509329]] },
     "temporal": { "interval": [["1985-01-17T11:00:00Z", "1985-01-27T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_tasman_sn8415_1984_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_tasman_sn8415_1984_0.375m/rgb/2193/collection.json
@@ -377,6 +377,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_tasman_sn8415_1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[172.6212457, -42.340656, 173.3177252, -41.6268891]] },
     "temporal": { "interval": [["1984-11-07T11:00:00Z", "1984-11-26T11:00:00Z"]] }

--- a/stac/marlborough/marlborough_tasman_snc8423_1984_0.375m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_tasman_snc8423_1984_0.375m/rgb/2193/collection.json
@@ -258,6 +258,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_tasman_snc8423_1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[172.8267817, -41.8218648, 173.8325873, -41.300257]] },
     "temporal": { "interval": [["1984-10-22T12:00:00Z", "1984-10-22T12:00:00Z"]] }

--- a/stac/marlborough/marlborough_wellington_snc50451_2004-2005_0.75m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_wellington_snc50451_2004-2005_0.75m/rgb/2193/collection.json
@@ -423,6 +423,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "marlborough_wellington_snc50451_2004-2005_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.9709244, -42.2758078, 175.314389, -40.6985957]] },
     "temporal": { "interval": [["2004-12-26T11:00:00Z", "2005-02-18T11:00:00Z"]] }

--- a/stac/nelson/nelson_2008-2009_0.5m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2008-2009_0.5m/rgb/2193/collection.json
@@ -98,6 +98,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "nelson_2008-2009_0.5m",
   "extent": {
     "spatial": { "bbox": [[173.1719264, -41.4001631, 173.6011333, -41.0420661]] },
     "temporal": { "interval": [["2008-12-31T11:00:00Z", "2009-01-30T11:00:00Z"]] }

--- a/stac/nelson/nelson_2014_0.4m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2014_0.4m/rgb/2193/collection.json
@@ -98,6 +98,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "nelson_2014_0.4m",
   "extent": {
     "spatial": { "bbox": [[173.1719264, -41.4001631, 173.6011333, -41.0420661]] },
     "temporal": { "interval": [["2014-01-31T11:00:00Z", "2014-02-27T11:00:00Z"]] }

--- a/stac/nelson/nelson_2018-2019_0.3m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2018-2019_0.3m/rgb/2193/collection.json
@@ -98,6 +98,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "nelson_2018-2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[173.1719264, -41.4001631, 173.6011333, -41.0420661]] },
     "temporal": { "interval": [["2019-01-15T11:00:00Z", "2019-02-02T11:00:00Z"]] }

--- a/stac/nelson/nelson_2022_0.075m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2022_0.075m/rgb/2193/collection.json
@@ -1015,6 +1015,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "nelson_2022_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.1834789, -41.3934951, 173.5661143, -41.1006647]] },
     "temporal": { "interval": [["2022-01-14T11:00:00Z", "2022-01-15T11:00:00Z"]] }

--- a/stac/nelson/top-of-the-south-flood_2022_0.15m/rgb/2193/collection.json
+++ b/stac/nelson/top-of-the-south-flood_2022_0.15m/rgb/2193/collection.json
@@ -5336,6 +5336,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "top-of-the-south-flood_2022_0.15m",
   "extent": {
     "spatial": { "bbox": [[172.7779619, -41.5039845, 173.6804067, -40.7970765]] },
     "temporal": { "interval": [["2022-08-22T12:00:00Z", "2022-09-05T12:00:00Z"]] }

--- a/stac/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
@@ -472,6 +472,7 @@
   "linz:geospatial_category": "satellite-imagery",
   "linz:region": "new-zealand",
   "linz:security_classification": "unclassified",
+  "linz:slug": "new-zealand_2020-2021_10m",
   "extent": {
     "spatial": { "bbox": [[166.3157485, -47.5345307, 178.6357959, -34.0291036]] },
     "temporal": { "interval": [["2020-08-31T12:00:00Z", "2021-04-29T12:00:00Z"]] }

--- a/stac/new-zealand/new-zealand_2021-2022_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2021-2022_10m/rgb/2193/collection.json
@@ -472,6 +472,7 @@
   "linz:geospatial_category": "satellite-imagery",
   "linz:region": "new-zealand",
   "linz:security_classification": "unclassified",
+  "linz:slug": "new-zealand_2021-2022_10m",
   "extent": {
     "spatial": { "bbox": [[166.3157485, -47.5345307, 178.6357959, -34.0291036]] },
     "temporal": { "interval": [["2021-08-31T12:00:00Z", "2022-04-29T12:00:00Z"]] }

--- a/stac/new-zealand/new-zealand_2022-2023_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2022-2023_10m/rgb/2193/collection.json
@@ -472,6 +472,7 @@
   "linz:geospatial_category": "satellite-imagery",
   "linz:region": "new-zealand",
   "linz:security_classification": "unclassified",
+  "linz:slug": "new-zealand_2022-2023_10m",
   "extent": {
     "spatial": { "bbox": [[166.3157485, -47.5345307, 178.6357959, -34.0291036]] },
     "temporal": { "interval": [["2022-08-31T12:00:00Z", "2023-04-29T12:00:00Z"]] }

--- a/stac/new-zealand/new-zealand_2023-2024_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2023-2024_10m/rgb/2193/collection.json
@@ -2724,6 +2724,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-09-30T23:36:30Z",
   "updated": "2024-09-30T23:36:30Z",
+  "linz:slug": "new-zealand_2023-2024_10m",
   "extent": {
     "spatial": { "bbox": [[166.3157485, -47.5345307, 178.6357959, -34.0291036]] },
     "temporal": { "interval": [["2023-08-31T12:00:00Z", "2024-04-29T12:00:00Z"]] }

--- a/stac/new-zealand/north-island_20221122_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_20221122_10m/rgb/2193/collection.json
@@ -177,6 +177,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "European Space Agency", "roles": ["producer"] }
   ],
+  "linz:slug": "north-island_20221122_10m",
   "extent": {
     "spatial": { "bbox": [[173.4291746, -41.8210614, 178.3861945, -36.5982342]] },
     "temporal": { "interval": [["2022-11-21T11:00:00Z", "2022-11-21T11:00:00Z"]] }

--- a/stac/new-zealand/north-island_20230220_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_20230220_10m/rgb/2193/collection.json
@@ -177,6 +177,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "European Space Agency", "roles": ["producer"] }
   ],
+  "linz:slug": "north-island_20230220_10m",
   "extent": {
     "spatial": { "bbox": [[173.4170765, -41.8065264, 178.6357959, -35.9498962]] },
     "temporal": { "interval": [["2022-02-19T11:00:00Z", "2022-02-19T11:00:00Z"]] }

--- a/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
@@ -1573,6 +1573,7 @@
     { "name": "Chang Guang Satellite Technology", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "north-island_2023_0.5m",
   "extent": {
     "spatial": { "bbox": [[175.2700705, -41.6259979, 178.5669558, -37.5202786]] },
     "temporal": { "interval": [["2023-02-20T11:00:00Z", "2023-03-07T11:00:00Z"]] }

--- a/stac/northland/northland_2003_0.75m/rgb/2193/collection.json
+++ b/stac/northland/northland_2003_0.75m/rgb/2193/collection.json
@@ -246,6 +246,7 @@
     { "name": "Northland Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.7993103, -36.4000347, 174.6277167, -36.036692]] },
     "temporal": { "interval": [["2003-10-02T12:00:00Z", "2003-10-02T12:00:00Z"]] }

--- a/stac/northland/northland_2003_1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2003_1m/rgb/2193/collection.json
@@ -174,6 +174,7 @@
     { "name": "Terralink International Ltd", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2003_1m",
   "extent": {
     "spatial": { "bbox": [[172.6340503, -34.9112287, 173.2101798, -34.3913349]] },
     "temporal": { "interval": [["2003-08-26T12:00:00Z", "2004-03-01T11:00:00Z"]] }

--- a/stac/northland/northland_2004_0.78m/rgb/2193/collection.json
+++ b/stac/northland/northland_2004_0.78m/rgb/2193/collection.json
@@ -313,6 +313,7 @@
     { "name": "Northland Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2004_0.78m",
   "extent": {
     "spatial": { "bbox": [[173.1837629, -36.5286135, 174.3916578, -34.8460299]] },
     "temporal": { "interval": [["2004-03-01T11:00:00Z", "2005-02-02T11:00:00Z"]] }

--- a/stac/northland/northland_2006_1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2006_1m/rgb/2193/collection.json
@@ -353,6 +353,7 @@
     { "name": "Terralink International Ltd", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2006_1m",
   "extent": {
     "spatial": { "bbox": [[173.1849324, -35.721477, 174.3234455, -35.3584908]] },
     "temporal": { "interval": [["2006-01-07T11:00:00Z", "2006-01-07T11:00:00Z"]] }

--- a/stac/northland/northland_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2014-2015_0.1m/rgb/2193/collection.json
@@ -6568,6 +6568,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2014-2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.1102017, -36.1749915, 174.6025874, -34.8008356]] },
     "temporal": { "interval": [["2014-10-09T11:00:00Z", "2015-05-03T12:00:00Z"]] }

--- a/stac/northland/northland_2014-2016_0.4m/rgb/2193/collection.json
+++ b/stac/northland/northland_2014-2016_0.4m/rgb/2193/collection.json
@@ -2483,6 +2483,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2014-2016_0.4m",
   "extent": {
     "spatial": { "bbox": [[172.6077595, -36.9147157, 174.791452, -34.3588693]] },
     "temporal": { "interval": [["2014-11-08T11:00:00Z", "2016-06-30T12:00:00Z"]] }

--- a/stac/northland/northland_2016_0.1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2016_0.1m/rgb/2193/collection.json
@@ -3307,6 +3307,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "northland_2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.9004729, -36.3695389, 174.2640182, -34.609317]] },
     "temporal": { "interval": [["2016-03-19T11:00:00Z", "2016-07-01T12:00:00Z"]] }

--- a/stac/northland/northland_2023-2024_0.3m/rgb/2193/collection.json
+++ b/stac/northland/northland_2023-2024_0.3m/rgb/2193/collection.json
@@ -6582,6 +6582,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-08-01T23:47:14Z",
   "updated": "2024-09-25T02:02:21Z",
+  "linz:slug": "northland_2023-2024_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.6079116, -36.2986053, 174.8084793, -34.3593284]] },
     "temporal": { "interval": [["2023-11-12T11:00:00Z", "2024-07-11T12:00:00Z"]] }

--- a/stac/northland/northland_auckland_sn8104_1982-1983_0.4m/rgb/2193/collection.json
+++ b/stac/northland/northland_auckland_sn8104_1982-1983_0.4m/rgb/2193/collection.json
@@ -547,6 +547,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_auckland_sn8104_1982-1983_0.4m",
   "extent": {
     "spatial": { "bbox": [[173.7451108, -36.5286135, 174.9015111, -35.9407257]] },
     "temporal": { "interval": [["1982-09-01T12:00:00Z", "1983-01-09T11:00:00Z"]] }

--- a/stac/northland/northland_auckland_sn9482_1995-1996_0.8m/rgb/2193/collection.json
+++ b/stac/northland/northland_auckland_sn9482_1995-1996_0.8m/rgb/2193/collection.json
@@ -187,6 +187,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_auckland_sn9482_1995-1996_0.8m",
   "extent": {
     "spatial": { "bbox": [[173.718208, -36.6254244, 174.9023038, -35.8437109]] },
     "temporal": { "interval": [["1995-03-11T11:00:00Z", "1996-02-04T11:00:00Z"]] }

--- a/stac/northland/northland_sn5780_1980_0.8m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn5780_1980_0.8m/rgb/2193/collection.json
@@ -74,6 +74,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_sn5780_1980_0.8m",
   "extent": {
     "spatial": { "bbox": [[172.6079116, -35.0086035, 173.2891103, -34.3588693]] },
     "temporal": { "interval": [["1980-12-11T11:00:00Z", "1980-12-11T11:00:00Z"]] }

--- a/stac/northland/northland_sn5932_1981-1982_0.375m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn5932_1981-1982_0.375m/rgb/2193/collection.json
@@ -696,6 +696,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_sn5932_1981-1982_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.0525244, -35.4628006, 174.4545835, -34.8781386]] },
     "temporal": { "interval": [["1981-10-02T12:00:00Z", "1982-02-07T11:00:00Z"]] }

--- a/stac/northland/northland_sn8328_1984-1986_0.8m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn8328_1984-1986_0.8m/rgb/2193/collection.json
@@ -227,6 +227,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_sn8328_1984-1986_0.8m",
   "extent": {
     "spatial": { "bbox": [[173.1848584, -36.0451893, 174.6223831, -35.3325989]] },
     "temporal": { "interval": [["1984-02-19T11:00:00Z", "1986-11-20T11:00:00Z"]] }

--- a/stac/northland/northland_sn9281_1993_0.6m/rgb/2193/collection.json
+++ b/stac/northland/northland_sn9281_1993_0.6m/rgb/2193/collection.json
@@ -63,6 +63,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_sn9281_1993_0.6m",
   "extent": {
     "spatial": { "bbox": [[173.5572513, -35.9802797, 174.0870212, -35.3297149]] },
     "temporal": { "interval": [["1993-02-28T11:00:00Z", "1993-02-28T11:00:00Z"]] }

--- a/stac/northland/northland_snc12835_2005_0.64m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc12835_2005_0.64m/rgb/2193/collection.json
@@ -168,6 +168,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_snc12835_2005_0.64m",
   "extent": {
     "spatial": { "bbox": [[172.8165965, -36.0390327, 174.6223831, -34.3592032]] },
     "temporal": { "interval": [["2005-01-19T11:00:00Z", "2005-12-01T11:00:00Z"]] }

--- a/stac/northland/northland_snc5797_1980_0.375m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc5797_1980_0.375m/rgb/2193/collection.json
@@ -67,6 +67,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_snc5797_1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.4999586, -35.266228, 173.7912705, -35.0069876]] },
     "temporal": { "interval": [["1980-12-11T11:00:00Z", "1980-12-11T11:00:00Z"]] }

--- a/stac/northland/northland_snc8573_1985_0.3m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc8573_1985_0.3m/rgb/2193/collection.json
@@ -61,6 +61,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_snc8573_1985_0.3m",
   "extent": {
     "spatial": { "bbox": [[173.5523654, -35.2666682, 173.7912705, -35.0069876]] },
     "temporal": { "interval": [["1985-10-05T12:00:00Z", "1985-10-05T12:00:00Z"]] }

--- a/stac/northland/northland_snc9935_2000-2003_0.75m/rgb/2193/collection.json
+++ b/stac/northland/northland_snc9935_2000-2003_0.75m/rgb/2193/collection.json
@@ -279,6 +279,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "northland_snc9935_2000-2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.6079116, -35.786626, 174.4017039, -34.3588693]] },
     "temporal": { "interval": [["2000-03-03T11:00:00Z", "2003-04-25T12:00:00Z"]] }

--- a/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
@@ -1253,6 +1253,7 @@
     { "name": "Dunedin City Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "dunedin_2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[170.1016142, -45.9649081, 170.7406305, -45.2896267]] },
     "temporal": { "interval": [["2013-01-21T11:00:00Z", "2013-01-31T11:00:00Z"]] }

--- a/stac/otago/dunedin_2013_0.4m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2013_0.4m/rgb/2193/collection.json
@@ -546,6 +546,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "dunedin_2013_0.4m",
   "extent": {
     "spatial": { "bbox": [[169.7285083, -46.0669944, 170.7781554, -45.2232546]] },
     "temporal": { "interval": [["2013-02-17T11:00:00Z", "2013-02-26T11:00:00Z"]] }

--- a/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
@@ -1390,6 +1390,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "dunedin_2018-2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[170.1016142, -46.0275569, 170.746538, -45.2896267]] },
     "temporal": { "interval": [["2018-01-13T11:00:00Z", "2019-04-06T11:00:00Z"]] }

--- a/stac/otago/otago_2013-2014_0.4m/rgb/2193/collection.json
+++ b/stac/otago/otago_2013-2014_0.4m/rgb/2193/collection.json
@@ -547,6 +547,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "otago_2013-2014_0.4m",
   "extent": {
     "spatial": { "bbox": [[170.0793386, -45.6570136, 171.2353006, -44.8768243]] },
     "temporal": { "interval": [["2013-10-28T11:00:00Z", "2014-03-12T11:00:00Z"]] }

--- a/stac/otago/otago_2017-2019_0.3m/rgb/2193/collection.json
+++ b/stac/otago/otago_2017-2019_0.3m/rgb/2193/collection.json
@@ -2346,6 +2346,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "otago_2017-2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[167.9797132, -46.1317203, 170.8410772, -43.8774483]] },
     "temporal": { "interval": [["2017-12-27T11:00:00Z", "2019-04-06T11:00:00Z"]] }

--- a/stac/otago/otago_2018_0.1m/rgb/2193/collection.json
+++ b/stac/otago/otago_2018_0.1m/rgb/2193/collection.json
@@ -916,6 +916,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "otago_2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[169.1141488, -45.5686336, 170.1679453, -44.9494545]] },
     "temporal": { "interval": [["2018-01-14T11:00:00Z", "2018-01-28T11:00:00Z"]] }

--- a/stac/otago/otago_2019-2021_0.3m/rgb/2193/collection.json
+++ b/stac/otago/otago_2019-2021_0.3m/rgb/2193/collection.json
@@ -2687,6 +2687,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "otago_2019-2021_0.3m",
   "extent": {
     "spatial": { "bbox": [[168.6403978, -46.691381, 170.5305003, -44.3599714]] },
     "temporal": { "interval": [["2019-02-06T11:00:00Z", "2021-02-19T11:00:00Z"]] }

--- a/stac/otago/otago_2023-2024_0.1m/rgb/2193/collection.json
+++ b/stac/otago/otago_2023-2024_0.1m/rgb/2193/collection.json
@@ -9750,6 +9750,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-08-01T01:47:13Z",
   "updated": "2024-08-01T01:47:13Z",
+  "linz:slug": "otago_2023-2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[169.138494, -45.9774145, 170.7406305, -44.9625898]] },
     "temporal": { "interval": [["2023-10-24T11:00:00Z", "2024-02-17T11:00:00Z"]] }

--- a/stac/otago/otago_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/otago/otago_2023-2024_0.2m/rgb/2193/collection.json
@@ -2808,6 +2808,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-08-01T00:50:13Z",
   "updated": "2024-08-01T00:50:13Z",
+  "linz:slug": "otago_2023-2024_0.2m",
   "extent": {
     "spatial": { "bbox": [[169.7266139, -46.0669944, 170.7563895, -45.2232546]] },
     "temporal": { "interval": [["2023-11-24T11:00:00Z", "2024-02-13T11:00:00Z"]] }

--- a/stac/otago/otago_canterbury_sn9933_2000_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_canterbury_sn9933_2000_0.75m/rgb/2193/collection.json
@@ -200,6 +200,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_canterbury_sn9933_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.0247602, -45.432701, 171.2158977, -44.5847687]] },
     "temporal": { "interval": [["2000-03-22T12:00:00Z", "2000-03-22T12:00:00Z"]] }

--- a/stac/otago/otago_sn12544_1998_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn12544_1998_0.75m/rgb/2193/collection.json
@@ -91,6 +91,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn12544_1998_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.0076072, -45.7516477, 170.8240496, -45.3488375]] },
     "temporal": { "interval": [["1998-11-13T11:00:00Z", "1998-11-13T11:00:00Z"]] }

--- a/stac/otago/otago_sn3806_1975_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn3806_1975_0.375m/rgb/2193/collection.json
@@ -281,6 +281,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn3806_1975_0.375m",
   "extent": {
     "spatial": { "bbox": [[169.0380494, -46.5705676, 170.0762769, -46.1628215]] },
     "temporal": { "interval": [["1975-02-19T11:00:00Z", "1975-02-25T12:00:00Z"]] }

--- a/stac/otago/otago_sn5220_1978_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn5220_1978_0.75m/rgb/2193/collection.json
@@ -168,6 +168,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn5220_1978_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.0826873, -45.496309, 171.2079121, -44.832576]] },
     "temporal": { "interval": [["1978-02-16T11:00:00Z", "1978-02-16T11:00:00Z"]] }

--- a/stac/otago/otago_sn5359_1979_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn5359_1979_0.375m/rgb/2193/collection.json
@@ -362,6 +362,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn5359_1979_0.375m",
   "extent": {
     "spatial": { "bbox": [[169.0256638, -46.2257247, 170.3682332, -45.9031578]] },
     "temporal": { "interval": [["1979-02-14T11:00:00Z", "1979-02-14T11:00:00Z"]] }

--- a/stac/otago/otago_sn8180_1983_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8180_1983_0.75m/rgb/2193/collection.json
@@ -191,6 +191,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn8180_1983_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.5306348, -45.212784, 169.8694958, -44.4700598]] },
     "temporal": { "interval": [["1983-02-16T11:00:00Z", "1983-03-11T12:00:00Z"]] }

--- a/stac/otago/otago_sn8215_1983-1984_0.8m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8215_1983-1984_0.8m/rgb/2193/collection.json
@@ -147,6 +147,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn8215_1983-1984_0.8m",
   "extent": {
     "spatial": { "bbox": [[169.0040339, -45.9909767, 169.837381, -45.3191549]] },
     "temporal": { "interval": [["1983-04-03T12:00:00Z", "1984-01-01T11:00:00Z"]] }

--- a/stac/otago/otago_sn8286_1984_0.8m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8286_1984_0.8m/rgb/2193/collection.json
@@ -255,6 +255,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn8286_1984_0.8m",
   "extent": {
     "spatial": { "bbox": [[169.0452978, -46.0037466, 170.3462648, -45.0605221]] },
     "temporal": { "interval": [["1984-01-01T11:00:00Z", "1984-01-01T11:00:00Z"]] }

--- a/stac/otago/otago_sn8436_1984_0.64m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8436_1984_0.64m/rgb/2193/collection.json
@@ -282,6 +282,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn8436_1984_0.64m",
   "extent": {
     "spatial": { "bbox": [[168.5763338, -45.1635772, 170.4101341, -44.5257083]] },
     "temporal": { "interval": [["1984-12-30T11:00:00Z", "1984-12-30T11:00:00Z"]] }

--- a/stac/otago/otago_sn8479_1985_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8479_1985_0.375m/rgb/2193/collection.json
@@ -204,6 +204,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn8479_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[170.0899219, -45.9735345, 170.7781554, -45.6424571]] },
     "temporal": { "interval": [["1985-02-15T11:00:00Z", "1985-02-15T11:00:00Z"]] }

--- a/stac/otago/otago_sn8733_1987_0.375m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn8733_1987_0.375m/rgb/2193/collection.json
@@ -232,6 +232,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn8733_1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[170.1017091, -45.7199095, 170.8534494, -45.3835548]] },
     "temporal": { "interval": [["1987-03-05T12:00:00Z", "1987-03-19T12:00:00Z"]] }

--- a/stac/otago/otago_sn9087_1990-1991_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn9087_1990-1991_0.75m/rgb/2193/collection.json
@@ -200,6 +200,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn9087_1990-1991_0.75m",
   "extent": {
     "spatial": { "bbox": [[169.6302249, -46.1317203, 170.8190644, -45.1562321]] },
     "temporal": { "interval": [["1990-03-01T11:00:00Z", "1991-10-28T11:00:00Z"]] }

--- a/stac/otago/otago_sn9457_1995-1997_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn9457_1995-1997_0.75m/rgb/2193/collection.json
@@ -135,6 +135,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn9457_1995-1997_0.75m",
   "extent": {
     "spatial": { "bbox": [[169.3945426, -46.6343395, 170.4948743, -45.8080818]] },
     "temporal": { "interval": [["1995-03-10T11:00:00Z", "1997-02-12T11:00:00Z"]] }

--- a/stac/otago/otago_sn9937_2000_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_sn9937_2000_0.75m/rgb/2193/collection.json
@@ -82,6 +82,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_sn9937_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.0041414, -46.0051921, 170.8089914, -45.6077204]] },
     "temporal": { "interval": [["2000-03-16T11:00:00Z", "2000-03-22T12:00:00Z"]] }

--- a/stac/otago/otago_snc12780_2003_0.64m/rgb/2193/collection.json
+++ b/stac/otago/otago_snc12780_2003_0.64m/rgb/2193/collection.json
@@ -257,6 +257,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_snc12780_2003_0.64m",
   "extent": {
     "spatial": { "bbox": [[168.5456135, -45.2269151, 170.3581878, -44.4633709]] },
     "temporal": { "interval": [["2003-02-26T11:00:00Z", "2003-03-19T12:00:00Z"]] }

--- a/stac/otago/otago_snc25055_2001_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_snc25055_2001_0.75m/rgb/2193/collection.json
@@ -141,6 +141,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_snc25055_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.8527056, -45.1333316, 169.4487424, -44.7592751]] },
     "temporal": { "interval": [["2001-02-18T11:00:00Z", "2001-02-18T11:00:00Z"]] }

--- a/stac/otago/otago_snc25057_2001_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_snc25057_2001_0.75m/rgb/2193/collection.json
@@ -309,6 +309,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_snc25057_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.9978185, -46.0037466, 170.4042696, -45.0584085]] },
     "temporal": { "interval": [["2001-02-12T11:00:00Z", "2001-02-20T11:00:00Z"]] }

--- a/stac/otago/otago_southland_west-coast_sn8426_1984-1985_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_southland_west-coast_sn8426_1984-1985_0.75m/rgb/2193/collection.json
@@ -167,6 +167,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "otago_southland_west-coast_sn8426_1984-1985_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.7724309, -44.8579458, 168.8843816, -44.1781006]] },
     "temporal": { "interval": [["1984-12-02T11:00:00Z", "1985-03-08T12:00:00Z"]] }

--- a/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
@@ -184,6 +184,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "queenstown-lakes_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[169.0918736, -44.7568136, 169.2893251, -44.6062695]] },
     "temporal": { "interval": [["2022-12-06T11:00:00Z", "2023-01-25T11:00:00Z"]] }

--- a/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
@@ -516,6 +516,7 @@
     { "name": "Queenstown-Lakes District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "queenstown_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[168.6167982, -45.1078028, 168.863241, -44.9339579]] },
     "temporal": { "interval": [["2021-03-12T11:00:00Z", "2021-03-13T11:00:00Z"]] }

--- a/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
@@ -529,6 +529,7 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "invercargill_2016_0.05m",
   "extent": {
     "spatial": { "bbox": [[168.3178948, -46.6153242, 168.4043712, -46.3681297]] },
     "temporal": { "interval": [["2016-02-06T11:00:00Z", "2016-02-06T11:00:00Z"]] }

--- a/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
@@ -1713,6 +1713,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "invercargill_2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[168.1916795, -46.6279865, 168.5441519, -46.287563]] },
     "temporal": { "interval": [["2016-02-06T11:00:00Z", "2016-02-06T11:00:00Z"]] }

--- a/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
@@ -929,6 +929,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "invercargill_2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[168.2531261, -46.6153242, 168.4611922, -46.355213]] },
     "temporal": { "interval": [["2022-02-20T11:00:00Z", "2022-03-18T11:00:00Z"]] }

--- a/stac/southland/invercargill_2022_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.1m/rgb/2193/collection.json
@@ -1714,6 +1714,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "invercargill_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[168.1916795, -46.6279865, 168.5441519, -46.287563]] },
     "temporal": { "interval": [["2022-02-20T11:00:00Z", "2022-02-20T11:00:00Z"]] }

--- a/stac/southland/southland-central-otago_2013-2014_0.4m/rgb/2193/collection.json
+++ b/stac/southland/southland-central-otago_2013-2014_0.4m/rgb/2193/collection.json
@@ -2533,6 +2533,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] }
   ],
+  "linz:slug": "southland-central-otago_2013-2014_0.4m",
   "extent": {
     "spatial": { "bbox": [[167.33616, -46.6863264, 170.3855901, -44.4313005]] },
     "temporal": { "interval": [["2014-02-04T11:00:00Z", "2014-03-25T11:00:00Z"]] }

--- a/stac/southland/southland-central-otago_2015-2017_0.4m/rgb/2193/collection.json
+++ b/stac/southland/southland-central-otago_2015-2017_0.4m/rgb/2193/collection.json
@@ -1509,6 +1509,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "southland-central-otago_2015-2017_0.4m",
   "extent": {
     "spatial": { "bbox": [[167.3461123, -46.539127, 170.4681533, -44.9665157]] },
     "temporal": { "interval": [["2015-02-25T11:00:00Z", "2017-03-07T11:00:00Z"]] }

--- a/stac/southland/southland_2005-2011_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_2005-2011_0.75m/rgb/2193/collection.json
@@ -1114,6 +1114,7 @@
     { "name": "Unknown", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "southland_2005-2011_0.75m",
   "extent": {
     "spatial": { "bbox": [[166.39297, -47.3351152, 169.2782666, -44.2426806]] },
     "temporal": { "interval": [["2007-02-04T11:00:00Z", "2007-10-18T11:00:00Z"]] }

--- a/stac/southland/southland_2023_0.1m/rgb/2193/collection.json
+++ b/stac/southland/southland_2023_0.1m/rgb/2193/collection.json
@@ -3502,6 +3502,7 @@
     { "name": "Environment Southland", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "southland_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[167.5987691, -46.9381522, 169.1438288, -44.6648733]] },
     "temporal": { "interval": [["2023-01-07T11:00:00Z", "2023-04-29T12:00:00Z"]] }

--- a/stac/southland/southland_2023_0.25m/rgb/2193/collection.json
+++ b/stac/southland/southland_2023_0.25m/rgb/2193/collection.json
@@ -12858,6 +12858,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-07-08T04:40:02Z",
   "updated": "2024-07-08T04:40:02Z",
+  "linz:slug": "southland_2023_0.25m",
   "extent": {
     "spatial": { "bbox": [[167.2876352, -46.6863264, 169.3028879, -44.6247872]] },
     "temporal": { "interval": [["2023-01-06T11:00:00Z", "2024-04-13T12:00:00Z"]] }

--- a/stac/southland/southland_otago_sn5693_1980_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn5693_1980_0.75m/rgb/2193/collection.json
@@ -176,6 +176,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_sn5693_1980_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.5664457, -46.5580387, 169.4200735, -45.5020545]] },
     "temporal": { "interval": [["1980-02-13T11:00:00Z", "1980-12-28T11:00:00Z"]] }

--- a/stac/southland/southland_otago_sn8542_1985_0.375m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn8542_1985_0.375m/rgb/2193/collection.json
@@ -343,6 +343,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_sn8542_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[168.1871247, -46.6863264, 169.7816198, -46.3880237]] },
     "temporal": { "interval": [["1985-10-16T12:00:00Z", "1985-11-14T11:00:00Z"]] }

--- a/stac/southland/southland_otago_sn8565_1985-1987_0.8m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn8565_1985-1987_0.8m/rgb/2193/collection.json
@@ -323,6 +323,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_sn8565_1985-1987_0.8m",
   "extent": {
     "spatial": { "bbox": [[167.4321715, -45.7153871, 169.3677712, -44.9950946]] },
     "temporal": { "interval": [["1985-11-14T11:00:00Z", "1987-03-04T12:00:00Z"]] }

--- a/stac/southland/southland_otago_sn8996_1988_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn8996_1988_0.75m/rgb/2193/collection.json
@@ -214,6 +214,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_sn8996_1988_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.0513919, -45.1734577, 168.9036968, -44.4256649]] },
     "temporal": { "interval": [["1988-12-14T11:00:00Z", "1988-12-15T11:00:00Z"]] }

--- a/stac/southland/southland_otago_sn9613_1997_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_sn9613_1997_0.75m/rgb/2193/collection.json
@@ -233,6 +233,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_sn9613_1997_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.4214109, -46.5085606, 169.8117148, -45.8156328]] },
     "temporal": { "interval": [["1997-02-04T11:00:00Z", "1997-02-12T11:00:00Z"]] }

--- a/stac/southland/southland_otago_snc12731_2002_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_snc12731_2002_0.75m/rgb/2193/collection.json
@@ -92,6 +92,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_snc12731_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.3997042, -46.691381, 169.7192302, -46.396991]] },
     "temporal": { "interval": [["2002-02-01T11:00:00Z", "2002-02-01T11:00:00Z"]] }

--- a/stac/southland/southland_otago_snc30012_2003_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_otago_snc30012_2003_0.75m/rgb/2193/collection.json
@@ -139,6 +139,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_otago_snc30012_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.5664457, -46.0366623, 169.2374115, -45.2389202]] },
     "temporal": { "interval": [["2003-02-26T11:00:00Z", "2003-03-15T11:00:00Z"]] }

--- a/stac/southland/southland_sn12545a_1998_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn12545a_1998_0.75m/rgb/2193/collection.json
@@ -92,6 +92,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn12545a_1998_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.9751438, -46.662764, 168.623159, -46.058575]] },
     "temporal": { "interval": [["1998-11-27T11:00:00Z", "1998-11-27T11:00:00Z"]] }

--- a/stac/southland/southland_sn8038_1982_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8038_1982_0.75m/rgb/2193/collection.json
@@ -148,6 +148,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn8038_1982_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.4615115, -45.9567363, 168.8380126, -45.5141308]] },
     "temporal": { "interval": [["1982-02-14T11:00:00Z", "1982-02-14T11:00:00Z"]] }

--- a/stac/southland/southland_sn8317_1984_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8317_1984_0.75m/rgb/2193/collection.json
@@ -142,6 +142,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn8317_1984_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.4356014, -46.2152274, 168.7568898, -45.7751206]] },
     "temporal": { "interval": [["1984-02-06T11:00:00Z", "1984-02-06T11:00:00Z"]] }

--- a/stac/southland/southland_sn8408_1984_0.375m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8408_1984_0.375m/rgb/2193/collection.json
@@ -385,6 +385,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn8408_1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[167.9721731, -46.4892438, 169.207095, -46.1217909]] },
     "temporal": { "interval": [["1984-11-01T11:00:00Z", "1984-11-01T11:00:00Z"]] }

--- a/stac/southland/southland_sn8541_1985_0.375m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn8541_1985_0.375m/rgb/2193/collection.json
@@ -163,6 +163,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn8541_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[167.4974811, -46.4149928, 168.1534743, -46.0976533]] },
     "temporal": { "interval": [["1985-10-17T12:00:00Z", "1985-10-17T12:00:00Z"]] }

--- a/stac/southland/southland_sn9066_1990-1991_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn9066_1990-1991_0.75m/rgb/2193/collection.json
@@ -36,6 +36,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn9066_1990-1991_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.5483851, -45.654755, 167.8293569, -45.264722]] },
     "temporal": { "interval": [["1990-01-06T11:00:00Z", "1991-02-18T11:00:00Z"]] }

--- a/stac/southland/southland_sn9067_1990_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn9067_1990_0.75m/rgb/2193/collection.json
@@ -76,6 +76,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn9067_1990_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.3051956, -46.2354901, 167.8056902, -45.517069]] },
     "temporal": { "interval": [["1990-01-06T11:00:00Z", "1990-02-21T11:00:00Z"]] }

--- a/stac/southland/southland_sn9421_1995_0.25m/rgb/2193/collection.json
+++ b/stac/southland/southland_sn9421_1995_0.25m/rgb/2193/collection.json
@@ -144,6 +144,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_sn9421_1995_0.25m",
   "extent": {
     "spatial": { "bbox": [[168.5329301, -46.2844271, 169.0876149, -45.9209436]] },
     "temporal": { "interval": [["1995-03-26T12:00:00Z", "1995-03-26T12:00:00Z"]] }

--- a/stac/southland/southland_snc30005a_2002_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_snc30005a_2002_0.75m/rgb/2193/collection.json
@@ -232,6 +232,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_snc30005a_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.4910198, -46.4539021, 168.7248938, -45.517069]] },
     "temporal": { "interval": [["2002-02-20T11:00:00Z", "2002-03-11T11:00:00Z"]] }

--- a/stac/southland/southland_snc30005b_2003_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_snc30005b_2003_0.75m/rgb/2193/collection.json
@@ -179,6 +179,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_snc30005b_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[167.4910198, -46.2549298, 168.2006134, -45.194473]] },
     "temporal": { "interval": [["2003-02-26T11:00:00Z", "2003-03-07T11:00:00Z"]] }

--- a/stac/southland/southland_snc30011_2003_0.75m/rgb/2193/collection.json
+++ b/stac/southland/southland_snc30011_2003_0.75m/rgb/2193/collection.json
@@ -99,6 +99,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "southland_snc30011_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.0949703, -45.7605571, 168.7492436, -45.2191692]] },
     "temporal": { "interval": [["2003-02-26T11:00:00Z", "2003-02-26T11:00:00Z"]] }

--- a/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
@@ -2116,6 +2116,7 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "new-plymouth_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.8614872, -39.2013367, 174.6007638, -38.8141385]] },
     "temporal": { "interval": [["2017-04-07T12:00:00Z", "2017-04-07T12:00:00Z"]] }

--- a/stac/taranaki/taranaki_2011-2012_0.4m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2011-2012_0.4m/rgb/2193/collection.json
@@ -899,6 +899,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2011-2012_0.4m",
   "extent": {
     "spatial": { "bbox": [[173.7232477, -39.8962506, 174.9585304, -38.6957157]] },
     "temporal": { "interval": [["2011-11-30T11:00:00Z", "2012-03-30T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_2016-2018_0.3m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2016-2018_0.3m/rgb/2193/collection.json
@@ -6060,6 +6060,7 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2016-2018_0.3m",
   "extent": {
     "spatial": { "bbox": [[173.740005, -39.8765518, 175.0709866, -38.6970509]] },
     "temporal": { "interval": [["2016-10-30T11:00:00Z", "2018-03-10T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_2021-2022_0.25m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2021-2022_0.25m/rgb/2193/collection.json
@@ -973,6 +973,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2021-2022_0.25m",
   "extent": {
     "spatial": { "bbox": [[173.7232477, -39.8962506, 175.0153988, -38.6957157]] },
     "temporal": { "interval": [["2021-11-23T11:00:00Z", "2022-01-07T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022-2023_0.05m/rgb/2193/collection.json
@@ -462,6 +462,7 @@
     { "name": "Taranaki Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2022-2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[173.7973698, -39.5503032, 174.8601595, -38.9760619]] },
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-04-29T12:00:00Z"]] }

--- a/stac/taranaki/taranaki_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022-2023_0.1m/rgb/2193/collection.json
@@ -867,6 +867,7 @@
     { "name": "Taranaki Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.7729585, -39.8694428, 174.7537975, -39.139632]] },
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-04-29T12:00:00Z"]] }

--- a/stac/taranaki/taranaki_2022_0.05m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022_0.05m/rgb/2193/collection.json
@@ -49,6 +49,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[174.4436952, -39.8354095, 174.6380232, -39.6593424]] },
     "temporal": { "interval": [["2022-01-07T11:00:00Z", "2022-03-22T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_2022_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022_0.1m/rgb/2193/collection.json
@@ -3000,6 +3000,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taranaki_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.8614872, -39.6256825, 174.6007638, -38.8141385]] },
     "temporal": { "interval": [["2022-01-07T11:00:00Z", "2022-03-22T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_manawatu-whanganui_sn8463_1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_manawatu-whanganui_sn8463_1985_0.375m/rgb/2193/collection.json
@@ -207,6 +207,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_manawatu-whanganui_sn8463_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.5626041, -39.7677488, 175.1572872, -39.4669564]] },
     "temporal": { "interval": [["1985-01-29T11:00:00Z", "1985-02-03T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn25016_2000_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn25016_2000_0.75m/rgb/2193/collection.json
@@ -53,6 +53,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn25016_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.7500269, -39.289747, 174.252259, -38.9611125]] },
     "temporal": { "interval": [["2000-01-13T11:00:00Z", "2000-01-13T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn5804_1981_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn5804_1981_0.375m/rgb/2193/collection.json
@@ -190,6 +190,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn5804_1981_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.7503716, -39.2573104, 174.4463338, -38.9588807]] },
     "temporal": { "interval": [["1981-01-09T11:00:00Z", "1981-03-29T12:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8003_1982_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8003_1982_0.75m/rgb/2193/collection.json
@@ -177,6 +177,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8003_1982_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.0258968, -39.8030442, 174.7660767, -38.8898709]] },
     "temporal": { "interval": [["1982-02-03T11:00:00Z", "1982-02-20T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8008_1982_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8008_1982_0.375m/rgb/2193/collection.json
@@ -175,6 +175,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8008_1982_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.7232477, -39.6114383, 174.2301309, -39.1907929]] },
     "temporal": { "interval": [["1982-01-29T11:00:00Z", "1982-02-03T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8298_1984_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8298_1984_0.375m/rgb/2193/collection.json
@@ -164,6 +164,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8298_1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.3025114, -39.252079, 174.7750714, -38.8894545]] },
     "temporal": { "interval": [["1984-01-07T11:00:00Z", "1984-01-07T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8349_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8349_1984-1985_0.375m/rgb/2193/collection.json
@@ -165,6 +165,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8349_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.1162411, -39.7702821, 174.709232, -39.4747505]] },
     "temporal": { "interval": [["1984-03-18T12:00:00Z", "1985-01-29T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8422_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8422_1984-1985_0.375m/rgb/2193/collection.json
@@ -236,6 +236,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8422_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.0843216, -39.5141427, 174.702067, -39.1825226]] },
     "temporal": { "interval": [["1984-11-26T11:00:00Z", "1985-01-29T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8502_1985_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8502_1985_0.375m/rgb/2193/collection.json
@@ -66,6 +66,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8502_1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.4126886, -39.023742, 174.6596289, -38.6640811]] },
     "temporal": { "interval": [["1985-03-17T12:00:00Z", "1985-03-17T12:00:00Z"]] }

--- a/stac/taranaki/taranaki_sn8771_1988_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_sn8771_1988_0.375m/rgb/2193/collection.json
@@ -122,6 +122,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_sn8771_1988_0.375m",
   "extent": {
     "spatial": { "bbox": [[173.861131, -39.4180648, 174.2534161, -39.0927634]] },
     "temporal": { "interval": [["1988-03-02T11:00:00Z", "1988-03-02T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_snc25044_2001_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_snc25044_2001_0.75m/rgb/2193/collection.json
@@ -152,6 +152,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_snc25044_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.8643151, -39.8665131, 174.6555467, -38.8266139]] },
     "temporal": { "interval": [["2001-02-23T11:00:00Z", "2001-02-23T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_snc30004_2002_0.75m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_snc30004_2002_0.75m/rgb/2193/collection.json
@@ -76,6 +76,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_snc30004_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[173.6951122, -39.548857, 174.3103226, -39.1557096]] },
     "temporal": { "interval": [["2002-02-17T11:00:00Z", "2002-02-17T11:00:00Z"]] }

--- a/stac/taranaki/taranaki_snc8923_1988_0.375m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_snc8923_1988_0.375m/rgb/2193/collection.json
@@ -45,6 +45,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "taranaki_snc8923_1988_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.5276401, -39.2817433, 174.7243666, -39.1496898]] },
     "temporal": { "interval": [["1988-01-22T11:00:00Z", "1988-01-22T11:00:00Z"]] }

--- a/stac/tasman/tasman_2001-2002_1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2001-2002_1m/rgb/2193/collection.json
@@ -267,6 +267,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2001-2002_1m",
   "extent": {
     "spatial": { "bbox": [[172.1014627, -42.2086634, 173.2595656, -40.5237282]] },
     "temporal": { "interval": [["2001-08-31T12:00:00Z", "2002-04-29T12:00:00Z"]] }

--- a/stac/tasman/tasman_2003_1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2003_1m/rgb/2193/collection.json
@@ -29,6 +29,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2003_1m",
   "extent": {
     "spatial": { "bbox": [[172.0595643, -40.9109456, 172.5178584, -40.588061]] },
     "temporal": { "interval": [["2002-12-31T11:00:00Z", "2003-12-30T11:00:00Z"]] }

--- a/stac/tasman/tasman_2004-2005_1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2004-2005_1m/rgb/2193/collection.json
@@ -147,6 +147,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2004-2005_1m",
   "extent": {
     "spatial": { "bbox": [[172.1174156, -41.2381103, 173.1419458, -40.4590873]] },
     "temporal": { "interval": [["2004-08-31T12:00:00Z", "2005-04-29T12:00:00Z"]] }

--- a/stac/tasman/tasman_2006-2007_1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2006-2007_1m/rgb/2193/collection.json
@@ -104,6 +104,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2006-2007_1m",
   "extent": {
     "spatial": { "bbox": [[172.7404344, -41.6921742, 173.2595656, -40.7839011]] },
     "temporal": { "interval": [["2006-06-30T12:00:00Z", "2006-07-30T12:00:00Z"]] }

--- a/stac/tasman/tasman_2009-2010_0.5m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2009-2010_0.5m/rgb/2193/collection.json
@@ -126,6 +126,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2009-2010_0.5m",
   "extent": {
     "spatial": { "bbox": [[172.1291164, -42.1434403, 172.9422605, -41.561662]] },
     "temporal": { "interval": [["2010-01-31T11:00:00Z", "2010-03-30T11:00:00Z"]] }

--- a/stac/tasman/tasman_2012-2013_0.4m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2012-2013_0.4m/rgb/2193/collection.json
@@ -334,6 +334,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2012-2013_0.4m",
   "extent": {
     "spatial": { "bbox": [[172.459042, -41.4651931, 173.2585295, -40.4918798]] },
     "temporal": { "interval": [["2012-09-30T11:00:00Z", "2012-11-29T11:00:00Z"]] }

--- a/stac/tasman/tasman_2015-2016_0.3m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2015-2016_0.3m/rgb/2193/collection.json
@@ -352,6 +352,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2015-2016_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.459042, -41.4651931, 173.2585295, -40.4916196]] },
     "temporal": { "interval": [["2015-11-12T11:00:00Z", "2016-01-08T11:00:00Z"]] }

--- a/stac/tasman/tasman_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2016-2017_0.3m/rgb/2193/collection.json
@@ -356,6 +356,7 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2016-2017_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.1046388, -42.1438226, 173.115017, -41.2703388]] },
     "temporal": { "interval": [["2016-12-07T11:00:00Z", "2017-02-04T11:00:00Z"]] }

--- a/stac/tasman/tasman_2017_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2017_0.075m/rgb/2193/collection.json
@@ -95,6 +95,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2017_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.1434283, -41.3678217, 173.2180539, -41.3158805]] },
     "temporal": { "interval": [["2017-11-19T11:00:00Z", "2017-11-19T11:00:00Z"]] }

--- a/stac/tasman/tasman_2017_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2017_0.1m/rgb/2193/collection.json
@@ -318,6 +318,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.3122997, -41.8135051, 173.1263047, -40.6734161]] },
     "temporal": { "interval": [["2017-11-16T11:00:00Z", "2017-11-19T11:00:00Z"]] }

--- a/stac/tasman/tasman_2018-2019_0.3m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2018-2019_0.3m/rgb/2193/collection.json
@@ -665,6 +665,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2018-2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.2024297, -41.627326, 173.3164527, -40.4916196]] },
     "temporal": { "interval": [["2019-01-01T11:00:00Z", "2019-03-03T11:00:00Z"]] }

--- a/stac/tasman/tasman_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020-2021_0.075m/rgb/2193/collection.json
@@ -183,6 +183,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2020-2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.126217, -41.3743274, 173.2295531, -41.3093127]] },
     "temporal": { "interval": [["2020-10-15T11:00:00Z", "2021-01-14T11:00:00Z"]] }

--- a/stac/tasman/tasman_2020_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020_0.1m/rgb/2193/collection.json
@@ -1074,6 +1074,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2020_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.300672, -41.82012, 173.1435423, -40.6668243]] },
     "temporal": { "interval": [["2020-10-15T11:00:00Z", "2020-10-21T11:00:00Z"]] }

--- a/stac/tasman/tasman_2020_0.3m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020_0.3m/rgb/2193/collection.json
@@ -752,6 +752,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2020_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.0140185, -42.3395863, 173.0577105, -41.3339074]] },
     "temporal": { "interval": [["2020-01-15T11:00:00Z", "2020-12-15T11:00:00Z"]] }

--- a/stac/tasman/tasman_2022-2023_0.25m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2022-2023_0.25m/rgb/2193/collection.json
@@ -349,6 +349,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2022-2023_0.25m",
   "extent": {
     "spatial": { "bbox": [[172.1046388, -42.1438226, 172.9426343, -41.2703388]] },
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-03-30T11:00:00Z"]] }

--- a/stac/tasman/tasman_2022_0.3m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2022_0.3m/rgb/2193/collection.json
@@ -364,6 +364,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "tasman_2022_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.459042, -41.5300468, 173.2585295, -40.4916196]] },
     "temporal": { "interval": [["2022-01-29T11:00:00Z", "2022-03-14T11:00:00Z"]] }

--- a/stac/tasman/tasman_2023_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2023_0.075m/rgb/2193/collection.json
@@ -137,6 +137,7 @@
   "linz:geospatial_category": "urban-aerial-photos",
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
+  "linz:slug": "tasman_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.1319672, -41.3678355, 173.2237921, -41.3158095]] },
     "temporal": { "interval": [["2023-10-10T11:00:00Z", "2023-10-27T11:00:00Z"]] }

--- a/stac/tasman/tasman_2023_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2023_0.1m/rgb/2193/collection.json
@@ -660,6 +660,7 @@
   "linz:geospatial_category": "urban-aerial-photos",
   "linz:region": "tasman",
   "linz:security_classification": "unclassified",
+  "linz:slug": "tasman_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.3065212, -41.8136033, 173.137787, -40.6733288]] },
     "temporal": { "interval": [["2023-10-10T11:00:00Z", "2023-10-27T11:00:00Z"]] }

--- a/stac/tasman/tasman_marlborough_nelson_sn25020_2000_0.75m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_marlborough_nelson_sn25020_2000_0.75m/rgb/2193/collection.json
@@ -140,6 +140,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_marlborough_nelson_sn25020_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.6265704, -41.4975302, 173.8330015, -40.9783399]] },
     "temporal": { "interval": [["2000-01-12T11:00:00Z", "2000-02-27T11:00:00Z"]] }

--- a/stac/tasman/tasman_sn8209_1983_0.8m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_sn8209_1983_0.8m/rgb/2193/collection.json
@@ -77,6 +77,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_sn8209_1983_0.8m",
   "extent": {
     "spatial": { "bbox": [[172.1032821, -42.0156027, 172.7981153, -41.6242897]] },
     "temporal": { "interval": [["1983-03-16T12:00:00Z", "1983-11-14T11:00:00Z"]] }

--- a/stac/tasman/tasman_sn8531_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_sn8531_1985-1986_0.375m/rgb/2193/collection.json
@@ -278,6 +278,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_sn8531_1985-1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[172.6840202, -41.5624734, 173.3156658, -41.0760413]] },
     "temporal": { "interval": [["1985-09-12T12:00:00Z", "1986-01-30T11:00:00Z"]] }

--- a/stac/tasman/tasman_sn8821_1991_0.6m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_sn8821_1991_0.6m/rgb/2193/collection.json
@@ -81,6 +81,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_sn8821_1991_0.6m",
   "extent": {
     "spatial": { "bbox": [[172.6243184, -41.8217885, 173.0288408, -41.1729124]] },
     "temporal": { "interval": [["1991-02-04T11:00:00Z", "1991-02-04T11:00:00Z"]] }

--- a/stac/tasman/tasman_snc25049_2000_0.75m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc25049_2000_0.75m/rgb/2193/collection.json
@@ -84,6 +84,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_snc25049_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.6254499, -41.7569963, 173.3175652, -41.3026237]] },
     "temporal": { "interval": [["2000-12-04T11:00:00Z", "2000-12-04T11:00:00Z"]] }

--- a/stac/tasman/tasman_snc30002_2002_0.75m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc30002_2002_0.75m/rgb/2193/collection.json
@@ -68,6 +68,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_snc30002_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[172.68527, -41.2381958, 173.0859208, -40.7188997]] },
     "temporal": { "interval": [["2002-02-20T11:00:00Z", "2002-02-20T11:00:00Z"]] }

--- a/stac/tasman/tasman_snc5676_1980-1981_0.64m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc5676_1980-1981_0.64m/rgb/2193/collection.json
@@ -383,6 +383,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_snc5676_1980-1981_0.64m",
   "extent": {
     "spatial": { "bbox": [[172.1148215, -41.9515743, 173.3764422, -40.4590873]] },
     "temporal": { "interval": [["1980-01-29T11:00:00Z", "1981-01-10T11:00:00Z"]] }

--- a/stac/tasman/tasman_snc8054_1982_0.25m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_snc8054_1982_0.25m/rgb/2193/collection.json
@@ -105,6 +105,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_snc8054_1982_0.25m",
   "extent": {
     "spatial": { "bbox": [[172.6239387, -41.9189201, 172.9134778, -41.5296114]] },
     "temporal": { "interval": [["1982-02-15T11:00:00Z", "1982-02-15T11:00:00Z"]] }

--- a/stac/tasman/tasman_west-coast_sn8409_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_west-coast_sn8409_1984-1985_0.375m/rgb/2193/collection.json
@@ -523,6 +523,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_west-coast_sn8409_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[172.0849221, -41.1409136, 173.0856253, -40.4916196]] },
     "temporal": { "interval": [["1984-11-06T11:00:00Z", "1985-03-08T12:00:00Z"]] }

--- a/stac/tasman/tasman_west-coast_snc50452_2004-2005_0.64m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_west-coast_snc50452_2004-2005_0.64m/rgb/2193/collection.json
@@ -257,6 +257,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "tasman_west-coast_snc50452_2004-2005_0.64m",
   "extent": {
     "spatial": { "bbox": [[171.8764422, -41.6268891, 173.0855833, -40.4590873]] },
     "temporal": { "interval": [["2004-11-18T11:00:00Z", "2005-04-05T12:00:00Z"]] }

--- a/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
@@ -510,6 +510,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hamilton_2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.1773614, -37.8551303, 175.3601519, -37.6818198]] },
     "temporal": { "interval": [["2015-03-19T11:00:00Z", "2015-03-19T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
@@ -945,6 +945,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hamilton_2016-2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.1661045, -37.8685235, 175.3846497, -37.6687483]] },
     "temporal": { "interval": [["2017-01-03T11:00:00Z", "2017-02-05T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
@@ -1490,6 +1490,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hamilton_2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },
     "temporal": { "interval": [["2019-03-19T11:00:00Z", "2019-03-19T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
@@ -1488,6 +1488,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hamilton_2020-2021_0.05m",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },
     "temporal": { "interval": [["2020-12-27T11:00:00Z", "2021-01-29T11:00:00Z"]] }

--- a/stac/waikato/hamilton_2023_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2023_0.05m/rgb/2193/collection.json
@@ -1488,6 +1488,7 @@
     { "name": "Hamilton City Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hamilton_2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },
     "temporal": { "interval": [["2023-03-21T11:00:00Z", "2023-04-03T12:00:00Z"]] }

--- a/stac/waikato/otorohanga_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/otorohanga_2021_0.1m/rgb/2193/collection.json
@@ -135,6 +135,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "otorohanga_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.8005252, -38.2075793, 175.2578636, -37.9995767]] },
     "temporal": { "interval": [["2021-02-17T11:00:00Z", "2021-02-17T11:00:00Z"]] }

--- a/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
@@ -121,6 +121,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taupo_2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.7184284, -38.9684906, 175.7934701, -38.7146977]] },
     "temporal": { "interval": [["2018-12-17T11:00:00Z", "2019-01-03T11:00:00Z"]] }

--- a/stac/waikato/taupo_2021_0.15m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2021_0.15m/rgb/2193/collection.json
@@ -182,6 +182,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taupo_2021_0.15m",
   "extent": {
     "spatial": { "bbox": [[175.7519779, -39.0056729, 176.2961344, -38.3509748]] },
     "temporal": { "interval": [["2021-01-25T11:00:00Z", "2021-01-25T11:00:00Z"]] }

--- a/stac/waikato/taupo_2023_0.075m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2023_0.075m/rgb/2193/collection.json
@@ -462,6 +462,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "taupo_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.9005629, -38.804196, 176.1779105, -38.6149918]] },
     "temporal": { "interval": [["2023-02-13T11:00:00Z", "2023-02-13T11:00:00Z"]] }

--- a/stac/waikato/thames-coromandel_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/thames-coromandel_2021_0.1m/rgb/2193/collection.json
@@ -657,6 +657,7 @@
     { "name": "Waikato Local Authority Shares Services Limited (Waikato LASS)", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "thames-coromandel_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.4232468, -37.2397463, 175.8890123, -36.5212195]] },
     "temporal": { "interval": [["2021-01-26T11:00:00Z", "2021-02-11T11:00:00Z"]] }

--- a/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
@@ -662,6 +662,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waikato-district_2014_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.7080652, -37.8415177, 175.3991154, -37.2243943]] },
     "temporal": { "interval": [["2014-01-09T11:00:00Z", "2014-03-06T11:00:00Z"]] }

--- a/stac/waikato/waikato_2012-2013_0.5m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2012-2013_0.5m/rgb/2193/collection.json
@@ -3563,6 +3563,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waikato_2012-2013_0.5m",
   "extent": {
     "spatial": { "bbox": [[174.5716916, -39.3269841, 176.7069861, -36.3844038]] },
     "temporal": { "interval": [["2012-03-03T11:00:00Z", "2013-03-10T11:00:00Z"]] }

--- a/stac/waikato/waikato_2016-2019_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2016-2019_0.3m/rgb/2193/collection.json
@@ -3686,6 +3686,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waikato_2016-2019_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.5297583, -39.3269841, 176.7103599, -36.3811521]] },
     "temporal": { "interval": [["2016-09-09T12:00:00Z", "2019-04-14T12:00:00Z"]] }

--- a/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
@@ -92,6 +92,7 @@
     { "name": "Recon", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waikato_2021-2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[174.8591255, -37.8045678, 175.2160185, -37.2243607]] },
     "temporal": { "interval": [["2021-02-25T11:00:00Z", "2022-05-05T12:00:00Z"]] }

--- a/stac/waikato/waikato_2021-2023_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2023_0.3m/rgb/2193/collection.json
@@ -22422,6 +22422,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-08-27T21:48:32Z",
   "updated": "2024-08-27T21:48:32Z",
+  "linz:slug": "waikato_2021-2023_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.5297583, -39.329461, 176.7120508, -36.3811521]] },
     "temporal": { "interval": [["2021-01-23T11:00:00Z", "2024-03-19T11:00:00Z"]] }

--- a/stac/waikato/waikato_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021_0.1m/rgb/2193/collection.json
@@ -962,6 +962,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waikato_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.7023515, -37.8550235, 175.4160939, -37.2109235]] },
     "temporal": { "interval": [["2021-01-25T11:00:00Z", "2021-03-22T11:00:00Z"]] }

--- a/stac/waikato/waikato_2023-2024_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2023-2024_0.3m/rgb/2193/collection.json
@@ -12564,6 +12564,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-07-04T01:07:48Z",
   "updated": "2024-07-04T01:07:48Z",
+  "linz:slug": "waikato_2023-2024_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.5731104, -38.8237518, 176.1276692, -36.3811521]] },
     "temporal": { "interval": [["2023-11-08T11:00:00Z", "2024-03-18T11:00:00Z"]] }

--- a/stac/waikato/waikato_auckland_sn9919_2000_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_auckland_sn9919_2000_0.75m/rgb/2193/collection.json
@@ -92,6 +92,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_auckland_sn9919_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.0011049, -36.8032296, 175.9804216, -36.0228458]] },
     "temporal": { "interval": [["2000-03-08T11:00:00Z", "2000-03-08T11:00:00Z"]] }

--- a/stac/waikato/waikato_bay-of-plenty_sn12539_1999_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn12539_1999_0.75m/rgb/2193/collection.json
@@ -94,6 +94,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_bay-of-plenty_sn12539_1999_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.3544737, -37.6462345, 176.127492, -37.2438431]] },
     "temporal": { "interval": [["1999-01-05T11:00:00Z", "1999-01-05T11:00:00Z"]] }

--- a/stac/waikato/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn5944_1981-1982_0.375m/rgb/2193/collection.json
@@ -393,6 +393,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_bay-of-plenty_sn5944_1981-1982_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.4106254, -37.8714954, 176.0691764, -37.2769219]] },
     "temporal": { "interval": [["1981-10-29T11:00:00Z", "1982-03-03T11:00:00Z"]] }

--- a/stac/waikato/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn5945_1981-1984_0.4m/rgb/2193/collection.json
@@ -697,6 +697,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_bay-of-plenty_sn5945_1981-1984_0.4m",
   "extent": {
     "spatial": { "bbox": [[175.4306147, -38.4213859, 176.5003244, -37.8137435]] },
     "temporal": { "interval": [["1981-10-29T11:00:00Z", "1984-01-07T11:00:00Z"]] }

--- a/stac/waikato/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_sn9445_1995-1997_0.75m/rgb/2193/collection.json
@@ -239,6 +239,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_bay-of-plenty_sn9445_1995-1997_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.3708375, -38.4856126, 176.5448849, -37.6841893]] },
     "temporal": { "interval": [["1995-12-08T11:00:00Z", "1997-01-26T11:00:00Z"]] }

--- a/stac/waikato/waikato_bay-of-plenty_snc12836_2004_0.625m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_snc12836_2004_0.625m/rgb/2193/collection.json
@@ -68,6 +68,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_bay-of-plenty_snc12836_2004_0.625m",
   "extent": {
     "spatial": { "bbox": [[175.8088658, -38.2848528, 176.2099049, -37.8214392]] },
     "temporal": { "interval": [["2004-03-24T12:00:00Z", "2004-03-24T12:00:00Z"]] }

--- a/stac/waikato/waikato_bay-of-plenty_snc25060_2001_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_bay-of-plenty_snc25060_2001_0.75m/rgb/2193/collection.json
@@ -88,6 +88,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_bay-of-plenty_snc25060_2001_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.8940124, -38.9963486, 176.5737974, -38.590991]] },
     "temporal": { "interval": [["2001-02-03T11:00:00Z", "2001-02-03T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn5164_1977-1979_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn5164_1977-1979_0.375m/rgb/2193/collection.json
@@ -476,6 +476,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn5164_1977-1979_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.6518705, -37.6242902, 175.5558535, -36.9983112]] },
     "temporal": { "interval": [["1977-11-03T11:00:00Z", "1979-09-26T12:00:00Z"]] }

--- a/stac/waikato/waikato_sn5479_1979_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn5479_1979_0.375m/rgb/2193/collection.json
@@ -547,6 +547,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn5479_1979_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.6692333, -38.1448032, 175.5738439, -37.5450129]] },
     "temporal": { "interval": [["1979-09-26T12:00:00Z", "1979-12-04T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn6656_1985-1987_0.6m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn6656_1985-1987_0.6m/rgb/2193/collection.json
@@ -81,6 +81,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn6656_1985-1987_0.6m",
   "extent": {
     "spatial": { "bbox": [[175.5498762, -38.608895, 176.2763828, -38.2101873]] },
     "temporal": { "interval": [["1985-03-20T12:00:00Z", "1987-01-27T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn8163_1983-1984_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8163_1983-1984_0.375m/rgb/2193/collection.json
@@ -426,6 +426,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn8163_1983-1984_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.3039307, -37.3544405, 175.9698825, -36.4443949]] },
     "temporal": { "interval": [["1983-01-09T11:00:00Z", "1984-01-24T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn8166_1983_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8166_1983_0.75m/rgb/2193/collection.json
@@ -191,6 +191,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn8166_1983_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.5702773, -38.6976531, 175.7288195, -38.0942402]] },
     "temporal": { "interval": [["1983-01-26T11:00:00Z", "1983-03-04T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn8297_1984_0.4m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8297_1984_0.4m/rgb/2193/collection.json
@@ -389,6 +389,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn8297_1984_0.4m",
   "extent": {
     "spatial": { "bbox": [[175.4720913, -38.6818629, 176.5025711, -38.3319233]] },
     "temporal": { "interval": [["1984-01-07T11:00:00Z", "1984-04-12T12:00:00Z"]] }

--- a/stac/waikato/waikato_sn8687_1986-1987_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn8687_1986-1987_0.375m/rgb/2193/collection.json
@@ -164,6 +164,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn8687_1986-1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.4578624, -38.941741, 176.045401, -38.6134158]] },
     "temporal": { "interval": [["1986-11-20T11:00:00Z", "1987-02-08T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn9124_1990-1991_0.48m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9124_1990-1991_0.48m/rgb/2193/collection.json
@@ -708,6 +708,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn9124_1990-1991_0.48m",
   "extent": {
     "spatial": { "bbox": [[174.9512807, -37.8933167, 176.0267604, -37.2769219]] },
     "temporal": { "interval": [["1990-11-01T11:00:00Z", "1991-11-29T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn9361_1994-1995_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9361_1994-1995_0.75m/rgb/2193/collection.json
@@ -101,6 +101,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn9361_1994-1995_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.3524576, -37.4471736, 175.9981258, -36.8562539]] },
     "temporal": { "interval": [["1994-05-04T12:00:00Z", "1995-12-02T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn9401_1995_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9401_1995_0.75m/rgb/2193/collection.json
@@ -152,6 +152,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn9401_1995_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.9283522, -38.2369466, 175.6407896, -37.4483442]] },
     "temporal": { "interval": [["1995-02-15T11:00:00Z", "1995-02-15T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn9584_1996-1997_0.64m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9584_1996-1997_0.64m/rgb/2193/collection.json
@@ -124,6 +124,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn9584_1996-1997_0.64m",
   "extent": {
     "spatial": { "bbox": [[175.3897557, -38.6835907, 176.5576317, -38.3302787]] },
     "temporal": { "interval": [["1996-10-11T11:00:00Z", "1997-12-03T11:00:00Z"]] }

--- a/stac/waikato/waikato_sn9615_1997_0.8m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9615_1997_0.8m/rgb/2193/collection.json
@@ -136,6 +136,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn9615_1997_0.8m",
   "extent": {
     "spatial": { "bbox": [[174.6511614, -38.2420978, 175.1643783, -37.2612791]] },
     "temporal": { "interval": [["1997-01-26T11:00:00Z", "1997-04-14T12:00:00Z"]] }

--- a/stac/waikato/waikato_sn9859_1999_0.625m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_sn9859_1999_0.625m/rgb/2193/collection.json
@@ -315,6 +315,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_sn9859_1999_0.625m",
   "extent": {
     "spatial": { "bbox": [[175.345364, -39.2670112, 176.8502739, -38.2200418]] },
     "temporal": { "interval": [["1999-09-21T12:00:00Z", "1999-12-04T11:00:00Z"]] }

--- a/stac/waikato/waikato_snc12837_2003_0.75m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc12837_2003_0.75m/rgb/2193/collection.json
@@ -74,6 +74,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_snc12837_2003_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.8492409, -39.3189165, 176.2537806, -38.7284678]] },
     "temporal": { "interval": [["2003-12-18T11:00:00Z", "2003-12-18T11:00:00Z"]] }

--- a/stac/waikato/waikato_snc5876_1981_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc5876_1981_0.375m/rgb/2193/collection.json
@@ -104,6 +104,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_snc5876_1981_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.4170658, -36.8983329, 175.8499139, -36.6630634]] },
     "temporal": { "interval": [["1981-01-25T11:00:00Z", "1981-01-25T11:00:00Z"]] }

--- a/stac/waikato/waikato_snc8697_1986_0.375m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc8697_1986_0.375m/rgb/2193/collection.json
@@ -50,6 +50,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_snc8697_1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.1110671, -37.3590491, 175.4116623, -37.2571722]] },
     "temporal": { "interval": [["1986-12-01T11:00:00Z", "1986-12-01T11:00:00Z"]] }

--- a/stac/waikato/waikato_snc9990_2001-2003_0.6m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_snc9990_2001-2003_0.6m/rgb/2193/collection.json
@@ -1001,6 +1001,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "waikato_snc9990_2001-2003_0.6m",
   "extent": {
     "spatial": { "bbox": [[174.5389722, -39.455316, 176.6094364, -36.4119692]] },
     "temporal": { "interval": [["2001-11-04T11:00:00Z", "2003-03-04T11:00:00Z"]] }

--- a/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
@@ -2907,6 +2907,7 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "waipa_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.0694451, -38.1531959, 175.6996572, -37.7952575]] },
     "temporal": { "interval": [["2021-01-30T11:00:00Z", "2021-02-18T11:00:00Z"]] }

--- a/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
@@ -368,6 +368,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "carterton_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.487309, -41.2490246, 175.9617072, -40.9559098]] },
     "temporal": { "interval": [["2021-01-04T11:00:00Z", "2021-01-24T11:00:00Z"]] }

--- a/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
@@ -1234,6 +1234,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hutt-city_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.8468393, -41.3193504, 175.0026514, -41.1429728]] },
     "temporal": { "interval": [["2017-02-27T11:00:00Z", "2017-03-04T11:00:00Z"]] }

--- a/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
@@ -1238,6 +1238,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "hutt-city_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8468393, -41.3193504, 175.0026514, -41.1429728]] },
     "temporal": { "interval": [["2021-01-12T11:00:00Z", "2021-01-26T11:00:00Z"]] }

--- a/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
@@ -2703,6 +2703,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "kapiti-coast_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.9290902, -41.0140691, 175.2151345, -40.699395]] },
     "temporal": { "interval": [["2017-02-23T11:00:00Z", "2017-02-23T11:00:00Z"]] }

--- a/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
@@ -2703,6 +2703,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "kapiti-coast_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.9290902, -41.0140691, 175.2151345, -40.699395]] },
     "temporal": { "interval": [["2021-01-13T11:00:00Z", "2021-01-13T11:00:00Z"]] }

--- a/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
@@ -1088,6 +1088,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "masterton_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.5561002, -41.1066377, 176.2684264, -40.7719414]] },
     "temporal": { "interval": [["2021-01-03T11:00:00Z", "2021-01-24T11:00:00Z"]] }

--- a/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
@@ -267,6 +267,7 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "porirua_2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8064258, -41.1721178, 174.9267893, -41.0213641]] },
     "temporal": { "interval": [["2016-01-31T11:00:00Z", "2016-03-05T11:00:00Z"]] }

--- a/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
@@ -1685,6 +1685,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "porirua_2020_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.797855, -41.1754935, 174.9331697, -41.017981]] },
     "temporal": { "interval": [["2020-02-24T11:00:00Z", "2020-02-24T11:00:00Z"]] }

--- a/stac/wellington/porirua_2024_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2024_0.1m/rgb/2193/collection.json
@@ -690,6 +690,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Porirua",
+  "linz:slug": "porirua_2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.7657337, -41.1656353, 175.0006802, -41.0012497]] },
     "temporal": { "interval": [["2024-01-06T11:00:00Z", "2024-01-07T11:00:00Z"]] }

--- a/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
@@ -781,6 +781,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "south-wairarapa_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.1442312, -41.6052017, 175.5093756, -41.0510807]] },
     "temporal": { "interval": [["2021-01-04T11:00:00Z", "2021-01-24T11:00:00Z"]] }

--- a/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
@@ -463,6 +463,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "upper-hutt_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.9905276, -41.1783229, 175.1491, -41.0827532]] },
     "temporal": { "interval": [["2017-02-27T11:00:00Z", "2017-02-27T11:00:00Z"]] }

--- a/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
@@ -466,6 +466,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "upper-hutt_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.9905276, -41.1783229, 175.1491, -41.0827532]] },
     "temporal": { "interval": [["2021-01-24T11:00:00Z", "2021-01-26T11:00:00Z"]] }

--- a/stac/wellington/wairarapa_sn11640_1989_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wairarapa_sn11640_1989_0.75m/rgb/2193/collection.json
@@ -4757,6 +4757,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Wairarapa",
+  "linz:slug": "wairarapa_sn11640_1989_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.9508603, -41.6383317, 176.3536955, -40.6415376]] },
     "temporal": { "interval": [["1989-03-31T12:00:00Z", "1989-04-29T12:00:00Z"]] }

--- a/stac/wellington/wellington_2012-2013_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2012-2013_0.1m/rgb/2193/collection.json
@@ -1638,6 +1638,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wellington_2012-2013_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.6964075, -41.3648867, 174.8641026, -41.1488854]] },
     "temporal": { "interval": [["2012-12-12T11:00:00Z", "2013-01-05T11:00:00Z"]] }

--- a/stac/wellington/wellington_2012-2013_0.3m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2012-2013_0.3m/rgb/2193/collection.json
@@ -1090,6 +1090,7 @@
     { "name": "Greater Wellington Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wellington_2012-2013_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.6035556, -41.6383317, 176.3536955, -40.6407393]] },
     "temporal": { "interval": [["2012-12-09T11:00:00Z", "2013-01-29T11:00:00Z"]] }

--- a/stac/wellington/wellington_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2016-2017_0.3m/rgb/2193/collection.json
@@ -1091,6 +1091,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wellington_2016-2017_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.6035556, -41.6383317, 176.3536955, -40.6407393]] },
     "temporal": { "interval": [["2017-01-05T11:00:00Z", "2017-02-24T11:00:00Z"]] }

--- a/stac/wellington/wellington_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2017_0.1m/rgb/2193/collection.json
@@ -1685,6 +1685,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wellington_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.6924387, -41.3648867, 174.8641026, -41.1488854]] },
     "temporal": { "interval": [["2017-02-23T11:00:00Z", "2017-03-04T11:00:00Z"]] }

--- a/stac/wellington/wellington_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2021_0.075m/rgb/2193/collection.json
@@ -2038,6 +2038,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wellington_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.6961558, -41.3681707, 174.8670568, -41.1456442]] },
     "temporal": { "interval": [["2021-01-12T11:00:00Z", "2021-01-12T11:00:00Z"]] }

--- a/stac/wellington/wellington_2021_0.3m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2021_0.3m/rgb/2193/collection.json
@@ -1090,6 +1090,7 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "wellington_2021_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.6035544, -41.6383317, 176.3536943, -40.6407394]] },
     "temporal": { "interval": [["2021-02-12T11:00:00Z", "2021-02-26T11:00:00Z"]] }

--- a/stac/wellington/wellington_2024_0.25m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2024_0.25m/rgb/2193/collection.json
@@ -3876,6 +3876,7 @@
   "linz:security_classification": "unclassified",
   "created": "2024-10-15T23:38:24Z",
   "updated": "2024-10-15T23:38:24Z",
+  "linz:slug": "wellington_2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[175.095257, -41.6383317, 176.3804297, -40.6091576]] },
     "temporal": { "interval": [["2024-04-02T11:00:00Z", "2024-05-05T12:00:00Z"]] }

--- a/stac/wellington/wellington_manawatu-whanganui_sn5139_1977_0.375m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn5139_1977_0.375m/rgb/2193/collection.json
@@ -480,6 +480,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_manawatu-whanganui_sn5139_1977_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.5771907, -41.4678773, 176.1149705, -40.4835006]] },
     "temporal": { "interval": [["1977-09-28T12:00:00Z", "1977-11-07T11:00:00Z"]] }

--- a/stac/wellington/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn5309_1978-1981_0.64m/rgb/2193/collection.json
@@ -161,6 +161,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_manawatu-whanganui_sn5309_1978-1981_0.64m",
   "extent": {
     "spatial": { "bbox": [[174.9659398, -41.2192272, 175.7656558, -40.3651142]] },
     "temporal": { "interval": [["1978-11-29T11:00:00Z", "1981-01-09T11:00:00Z"]] }

--- a/stac/wellington/wellington_manawatu-whanganui_sn8171_1983_0.375m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn8171_1983_0.375m/rgb/2193/collection.json
@@ -266,6 +266,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_manawatu-whanganui_sn8171_1983_0.375m",
   "extent": {
     "spatial": { "bbox": [[175.020918, -41.1788597, 175.7371751, -40.4972341]] },
     "temporal": { "interval": [["1983-02-01T11:00:00Z", "1983-03-16T12:00:00Z"]] }

--- a/stac/wellington/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_manawatu-whanganui_sn9382_1994-1995_0.75m/rgb/2193/collection.json
@@ -220,6 +220,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_manawatu-whanganui_sn9382_1994-1995_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.4406165, -41.5364623, 176.5985656, -40.4040406]] },
     "temporal": { "interval": [["1994-11-26T11:00:00Z", "1995-02-16T11:00:00Z"]] }

--- a/stac/wellington/wellington_sn11776_1991_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn11776_1991_0.75m/rgb/2193/collection.json
@@ -1738,6 +1738,7 @@
   "linz:geospatial_category": "scanned-aerial-photos",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
+  "linz:slug": "wellington_sn11776_1991_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.6035556, -41.4500301, 175.4439668, -40.6934704]] },
     "temporal": { "interval": [["1991-02-21T11:00:00Z", "1991-02-21T11:00:00Z"]] }

--- a/stac/wellington/wellington_sn5497_1979-1980_0.4m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn5497_1979-1980_0.4m/rgb/2193/collection.json
@@ -559,6 +559,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_sn5497_1979-1980_0.4m",
   "extent": {
     "spatial": { "bbox": [[174.6035556, -41.6383317, 175.6727506, -40.6667219]] },
     "temporal": { "interval": [["1979-10-10T12:00:00Z", "1980-10-05T12:00:00Z"]] }

--- a/stac/wellington/wellington_sn8790_1987-1988_0.375m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn8790_1987-1988_0.375m/rgb/2193/collection.json
@@ -295,6 +295,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_sn8790_1987-1988_0.375m",
   "extent": {
     "spatial": { "bbox": [[174.6035556, -41.4500301, 175.2375552, -40.7634106]] },
     "temporal": { "interval": [["1987-11-19T11:00:00Z", "1988-01-01T11:00:00Z"]] }

--- a/stac/wellington/wellington_sn9448_1995-1997_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_sn9448_1995-1997_0.75m/rgb/2193/collection.json
@@ -122,6 +122,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_sn9448_1995-1997_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.0268537, -41.6707333, 175.8421593, -40.949559]] },
     "temporal": { "interval": [["1995-09-23T12:00:00Z", "1997-02-13T11:00:00Z"]] }

--- a/stac/wellington/wellington_snc25047_2000_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_snc25047_2000_0.75m/rgb/2193/collection.json
@@ -80,6 +80,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_snc25047_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[174.5749311, -41.4824399, 175.2110841, -40.9578505]] },
     "temporal": { "interval": [["2000-12-03T11:00:00Z", "2000-12-03T11:00:00Z"]] }

--- a/stac/wellington/wellington_snc25062_2000_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_snc25062_2000_0.75m/rgb/2193/collection.json
@@ -91,6 +91,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_snc25062_2000_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.4759681, -41.1452124, 176.2243609, -40.7394702]] },
     "temporal": { "interval": [["2000-12-04T11:00:00Z", "2000-12-05T11:00:00Z"]] }

--- a/stac/wellington/wellington_snc30010_2002_0.75m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_snc30010_2002_0.75m/rgb/2193/collection.json
@@ -82,6 +82,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "wellington_snc30010_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[175.0189523, -41.1554358, 175.7738102, -40.757668]] },
     "temporal": { "interval": [["2002-03-11T11:00:00Z", "2002-03-11T11:00:00Z"]] }

--- a/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
+++ b/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
@@ -614,6 +614,7 @@
     { "name": "Buller District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "buller_2020_0.2m",
   "extent": {
     "spatial": { "bbox": [[171.3214966, -42.1343457, 172.2267458, -41.1048994]] },
     "temporal": { "interval": [["2020-05-14T12:00:00Z", "2020-10-14T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_2009-2011_0.4m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_2009-2011_0.4m/rgb/2193/collection.json
@@ -1641,6 +1641,7 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "west-coast_2009-2011_0.4m",
   "extent": {
     "spatial": { "bbox": [[168.5645851, -44.0832067, 172.4461582, -41.1048542]] },
     "temporal": { "interval": [["2010-01-05T11:00:00Z", "2011-05-06T12:00:00Z"]] }

--- a/stac/west-coast/west-coast_2015-2016_0.3m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_2015-2016_0.3m/rgb/2193/collection.json
@@ -1364,6 +1364,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "west-coast_2015-2016_0.3m",
   "extent": {
     "spatial": { "bbox": [[171.0666438, -42.8479877, 172.4274907, -41.0724292]] },
     "temporal": { "interval": [["2015-12-25T11:00:00Z", "2016-05-31T12:00:00Z"]] }

--- a/stac/west-coast/west-coast_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_2016-2017_0.3m/rgb/2193/collection.json
@@ -1278,6 +1278,7 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "west-coast_2016-2017_0.3m",
   "extent": {
     "spatial": { "bbox": [[168.4401054, -44.1499927, 171.8561655, -42.4879949]] },
     "temporal": { "interval": [["2017-02-07T11:00:00Z", "2017-03-08T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_2016_0.1m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_2016_0.1m/rgb/2193/collection.json
@@ -1006,6 +1006,7 @@
     { "name": "West Coast Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:slug": "west-coast_2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[171.4403681, -42.1474067, 171.908972, -41.6854255]] },
     "temporal": { "interval": [["2016-12-19T11:00:00Z", "2016-12-19T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_canterbury_sn8585_1986-1987_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_canterbury_sn8585_1986-1987_0.75m/rgb/2193/collection.json
@@ -261,6 +261,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_canterbury_sn8585_1986-1987_0.75m",
   "extent": {
     "spatial": { "bbox": [[169.703513, -43.6248146, 171.4892743, -42.646005]] },
     "temporal": { "interval": [["1986-01-05T11:00:00Z", "1987-04-11T12:00:00Z"]] }

--- a/stac/west-coast/west-coast_otago_sn8321_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_otago_sn8321_1984-1985_0.375m/rgb/2193/collection.json
@@ -385,6 +385,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_otago_sn8321_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[168.0379359, -44.3228477, 169.3360342, -43.9405581]] },
     "temporal": { "interval": [["1984-02-11T11:00:00Z", "1985-03-23T12:00:00Z"]] }

--- a/stac/west-coast/west-coast_otago_sn9065_1990_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_otago_sn9065_1990_0.75m/rgb/2193/collection.json
@@ -141,6 +141,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_otago_sn9065_1990_0.75m",
   "extent": {
     "spatial": { "bbox": [[168.0297435, -44.3795502, 169.4318146, -43.9370519]] },
     "temporal": { "interval": [["1990-01-05T11:00:00Z", "1990-01-05T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn5781_1980_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn5781_1980_0.375m/rgb/2193/collection.json
@@ -91,6 +91,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn5781_1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[170.9181027, -42.7503513, 171.3628496, -42.551849]] },
     "temporal": { "interval": [["1980-10-12T12:00:00Z", "1980-10-12T12:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn5817_1980_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn5817_1980_0.375m/rgb/2193/collection.json
@@ -128,6 +128,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn5817_1980_0.375m",
   "extent": {
     "spatial": { "bbox": [[171.4076403, -41.9457361, 171.8476385, -41.6212575]] },
     "temporal": { "interval": [["1980-12-22T11:00:00Z", "1980-12-22T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn8312_1984-1985_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn8312_1984-1985_0.375m/rgb/2193/collection.json
@@ -530,6 +530,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn8312_1984-1985_0.375m",
   "extent": {
     "spatial": { "bbox": [[171.2148928, -42.7575266, 172.3587144, -42.2629596]] },
     "temporal": { "interval": [["1984-01-29T11:00:00Z", "1985-02-04T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn8534_1985-1986_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn8534_1985-1986_0.375m/rgb/2193/collection.json
@@ -472,6 +472,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn8534_1985-1986_0.375m",
   "extent": {
     "spatial": { "bbox": [[171.2522795, -42.338698, 172.3629563, -41.8764972]] },
     "temporal": { "interval": [["1985-09-19T12:00:00Z", "1986-01-05T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn8721_1987_0.375m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn8721_1987_0.375m/rgb/2193/collection.json
@@ -239,6 +239,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn8721_1987_0.375m",
   "extent": {
     "spatial": { "bbox": [[171.7882098, -41.7204159, 172.3143482, -41.0724292]] },
     "temporal": { "interval": [["1987-02-20T11:00:00Z", "1987-02-23T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn9493_1996_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn9493_1996_0.75m/rgb/2193/collection.json
@@ -129,6 +129,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn9493_1996_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.9148411, -42.9082699, 171.9209792, -42.1981434]] },
     "temporal": { "interval": [["1996-02-21T11:00:00Z", "1996-12-02T11:00:00Z"]] }

--- a/stac/west-coast/west-coast_sn9641_1997_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_sn9641_1997_0.75m/rgb/2193/collection.json
@@ -182,6 +182,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_sn9641_1997_0.75m",
   "extent": {
     "spatial": { "bbox": [[171.1592552, -42.5335418, 172.3925265, -41.8822663]] },
     "temporal": { "interval": [["1997-03-27T12:00:00Z", "1997-04-23T12:00:00Z"]] }

--- a/stac/west-coast/west-coast_snc30003_2002_0.75m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_snc30003_2002_0.75m/rgb/2193/collection.json
@@ -80,6 +80,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
+  "linz:slug": "west-coast_snc30003_2002_0.75m",
   "extent": {
     "spatial": { "bbox": [[170.6727618, -43.0415724, 171.3895703, -42.646005]] },
     "temporal": { "interval": [["2002-02-13T11:00:00Z", "2002-02-13T11:00:00Z"]] }

--- a/stac/west-coast/westport-flood_2021_0.125m/rgb/2193/collection.json
+++ b/stac/west-coast/westport-flood_2021_0.125m/rgb/2193/collection.json
@@ -127,6 +127,7 @@
   "linz:region": "west-coast",
   "linz:security_classification": "unclassified",
   "linz:geographic_description": "Westport Flood",
+  "linz:slug": "westport-flood_2021_0.125m",
   "extent": {
     "spatial": { "bbox": [[171.5843058, -41.8072992, 171.6378063, -41.72239]] },
     "temporal": { "interval": [["2021-07-23T12:00:00Z", "2021-07-23T12:00:00Z"]] }


### PR DESCRIPTION
### Motivation
An update to `topo-imagery` ([PR #1152](https://github.com/linz/topo-imagery/pull/1152)) and `argo-tasks` ([PR #1124](https://github.com/linz/argo-tasks/pull/1124)) will add the the `linz:slug` attribute new `collection.json` files and expect this attribute to be present with [release 4.8.0](https://github.com/linz/argo-tasks/pull/1127).
This pull request is to manually (one-off) add the new `linz:slug` attribute to all existing `collection.json` files in the `elevation` and `imagery` repositories.
Original motivation for this change is from BM-1076. 

### Modifications
Added `linz:slug` attribute to each `collection.json` file from its location in this repository.
```
#!/bin/bash
for dir in ./stac/*/*; do
  find $dir -type f -name 'collection.json' -print -exec sed -i 's;  "extent": {;  "linz:slug": "'${dir#./stac/*/}'",\n  "extent": {;g' {} \;
done
```

### Verification
Checked for invalid `json` using `jq`
```
echo "Checking for invalid json files"
shopt -s globstar
for file in ./**/collection.json; do
  jq . "${file}" >/dev/null || echo "failed: ${file}"
done
echo "DONE"
```
Checked for files containing multiple `linz:slug` attributes:
```
echo "Files with number of slugs not equal to 1:"
grep -R --include='collection.json' 'linz:slug' . -c --color=no | grep -v 'n:1$'
echo "END OF LIST"
```
