### PR TITLE
docs: revert to STAC Browser for browsing the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # New Zealand Imagery
 
-[![STAC Index Badge](https://img.shields.io/badge/New_Zealand_Imagery-%2309B3AD?style=flat&label=Open%20in%20STAC%20Index&labelColor=%23144E63&link=https%3A%2F%2Fstacindex.org%2Fcatalogs%2Fnz-imagery%23%2F)](https://stacindex.org/catalogs/nz-imagery#/)
+[![STAC Browser Badge](https://img.shields.io/badge/Open_in_STAC_Browser-%2309B3AD?style=flat&label=New%20Zealand%20Imagery&labelColor=%23144E63)](https://radiantearth.github.io/stac-browser/#/external/nz-imagery.s3-ap-southeast-2.amazonaws.com/catalog.json)
+[![AWS Badge](https://img.shields.io/badge/Open_in_Registry_of_Open_Data_on_AWS-%23FF9900.svg?logo=amazon-web-services&logoColor=white&labelColor=%23232F3E)](https://registry.opendata.aws/nz-imagery/)
 
 Toitū Te Whenua makes New Zealand's most up-to-date publicly owned aerial imagery freely available to use under an open licence. You can access this through the [LINZ Data Service](https://data.linz.govt.nz/data/category/aerial-photos/?s=n), [LINZ Basemaps](https://basemaps.linz.govt.nz/#@-41.8899962,174.0492437,z5) or the [Registry of Open Data on AWS](https://registry.opendata.aws/nz-imagery/).
 
 ## Quickstart
 
-Browse the archive with [STAC Index](https://stacindex.org/catalogs/nz-imagery#/) or access the catalog directly [https://nz-imagery.s3-ap-southeast-2.amazonaws.com/catalog.json](https://nz-imagery.s3-ap-southeast-2.amazonaws.com/catalog.json)
+Browse the archive with [STAC Browser](https://radiantearth.github.io/stac-browser/#/external/nz-imagery.s3-ap-southeast-2.amazonaws.com/catalog.json) or access the catalog directly [https://nz-imagery.s3-ap-southeast-2.amazonaws.com/catalog.json](https://nz-imagery.s3-ap-southeast-2.amazonaws.com/catalog.json)
 
 ## Background
 
 This repository contains STAC Collection metadata for each imagery dataset, as well as some guidance documentation:
 
-- [Naming](docs/naming.md) covers the `s3://nz-imagery bucket` naming structure
+- [Naming](docs/naming.md) covers the `s3://nz-imagery` bucket naming structure
 - [Tools](docs/tools.md) covers some of the STAC ecosystem tools that can be used to interact with our STAC Catalog
 - [Usage](docs/usage.md) shows how TIFFs can be interacted with from S3 using GDAL, QGIS, etc
 
@@ -25,6 +26,10 @@ Using the [AWS CLI](https://aws.amazon.com/cli/) anyone can access all of the im
 ```
 aws s3 ls --no-sign-request s3://nz-imagery/
 ```
+
+## Related
+
+For access to LINZ's elevation data see [linz/elevation](https://github.com/linz/elevation)
 
 ## License
 


### PR DESCRIPTION
### Motivation

STAC Index is using an older version of STAC Browser that isn't as easy to browse through. We've received feedback that the previous link was more helpful.

### Modifications

Reverted browsing links to go to STAC Browser rather than STAC Index.
Added a badge + link through to Registry of Open Data on AWS.