### PR TITLE
fix: tauranga-winter_2022_0.1m title

### DIFF
--- a/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
@@ -3,7 +3,7 @@
   "stac_version": "1.0.0",
   "id": "01GK2DPV3T9PC8C9QG7FH1GQDQ",
   "title": "Tauranga Winter 0.1m Urban Aerial Photos (2022)",
-  "description": "Orthophotography within the Tauranga Region captured in August 2022.",
+  "description": "Orthophotography within the Bay of Plenty Region captured in August 2022.",
   "license": "CC-BY-4.0",
   "links": [
     {
@@ -18601,6 +18601,7 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
   "linz:slug": "tauranga-winter_2022_0.1m",
+  "linz:geographic_description": "Tauranga Winter",
   "extent": {
     "spatial": { "bbox": [[176.056766, -37.7948242, 176.4270065, -37.6207199]] },
     "temporal": { "interval": [["2022-07-31T12:00:00Z", "2022-08-04T12:00:00Z"]] }

--- a/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GK2DPV3T9PC8C9QG7FH1GQDQ",
-  "title": "Tauranga City 0.1m Urban Aerial Photos (2022)",
+  "title": "Tauranga Winter 0.1m Urban Aerial Photos (2022)",
   "description": "Orthophotography within the Tauranga Region captured in August 2022.",
   "license": "CC-BY-4.0",
   "links": [


### PR DESCRIPTION
Original title belongs to [tauranga_2022_0.1m](https://github.com/linz/imagery/blob/master/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json)
