### PR TITLE
fix: fixed year in waimate_2021_0.075m title

### DIFF
--- a/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GKSMTCH2MF6ZR7609RMAP946",
-  "title": "Waimate 0.075m Urban Aerial Photos (2021-2022)",
+  "title": "Waimate 0.075m Urban Aerial Photos (2021)",
   "description": "Orthophotography within the Canterbury region captured in the 2021-2022 flying season.",
   "license": "CC-BY-4.0",
   "links": [


### PR DESCRIPTION
Year in title was 2021-2022, should just be 2021.
Path contains correct year and flown dates are in 2021. This will make it consistent with LDS title too.