### PR TITLE
fix: remove collection link to BW23_500_044097.json item TDE-1669

### DIFF
--- a/stac/canterbury/waimakariri_2025_0.04m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2025_0.04m/rgb/2193/collection.json
@@ -2053,12 +2053,6 @@
       "file:checksum": "122056d1917c344859d46c389bbfefb02653271172cbf78a9b0288c87f1e9dd909f0"
     },
     {
-      "href": "./BW23_500_044097.json",
-      "rel": "item",
-      "type": "application/geo+json",
-      "file:checksum": "122029d2a29fc26477b9ad622166418abcf3eb759ac4e4b6c630ccc61acfa0e28bbe"
-    },
-    {
       "href": "./BW23_500_044098.json",
       "rel": "item",
       "type": "application/geo+json",


### PR DESCRIPTION
`BW23_500_044097` JSON item link needs to be removed from the collection as the TIFF does not exist (was outside the cutline).