### PR TITLE
fix: taupo_2021_0.15m should be taupo_2021_0.1m

### DIFF
--- a/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GX7RTNKN2NAR4N6ZY9QNHGXH",
-  "title": "Taupō 0.15m Urban Aerial Photos (2021)",
+  "title": "Taupō 0.1m Urban Aerial Photos (2021)",
   "description": "Orthophotography within the Taupō District captured in the 2020-2021 flying season.",
   "license": "CC-BY-4.0",
   "links": [
@@ -1002,12 +1002,12 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
-  "linz:slug": "taupo_2021_0.15m",
+  "linz:slug": "taupo_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.7519779, -39.0056729, 176.2961344, -38.3509748]] },
     "temporal": { "interval": [["2021-01-25T11:00:00Z", "2021-01-25T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-04-10T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }


### PR DESCRIPTION
### Motivation

`taupo_2021_0.15m` should be `taupo_2021_0.1m`
<!-- TODO: Say why you made your changes. -->

### Modifications

Fix Collection title, slug and path
Items and assets have been moved to `s3://nz-imagery/waikato/taupo_2021_0.1m/rgb/2193/` 
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
