### PR TITLE
ci: use new merge queue concurrency control TDE-1124

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
 
       - name: Run actionlint to check workflow files
-        run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -color
+        run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -ignore 'unexpected key "queue" for "concurrency" section' -color
 
   publish-odr:
     name: Publish ODR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Download actionlint
         run: docker build --tag actionlint - < .github/workflows/actionlint.dockerfile
 
+        # ignore 'unexpected key "queue" for "concurrency" section' as new label not yet in schema
       - name: Run actionlint to check workflow files
         run: docker run --volume="${PWD}:/repo" --workdir=/repo actionlint -ignore 'unexpected key "queue" for "concurrency" section' -color
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: publish-queue
+  queue: max
+
 jobs:
   main:
     name: Validate STAC


### PR DESCRIPTION
### Motivation & Modifications

Use the [new (as yet formally undocumented) GitHub Actions merge queue feature](https://github.com/orgs/community/discussions/12835#discussioncomment-16602100). This queues actions in a pending state rather than cancelling/skipping them.

Note that the new "queue" label needs to be ignored by the linter as it is not yet in the linter's schema.

### Verification

Tested on test repo
<img width="1300" height="243" alt="Screenshot from 2026-04-28 13-57-03" src="https://github.com/user-attachments/assets/1122cd40-7a52-4c09-8594-73ec9c2f7b00" />

