### PR TITLE
fix: remove missing Mackenzie file CA16_5000_0806 

### DIFF
--- a/stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json
@@ -4956,7 +4956,7 @@
     "temporal": { "interval": [["2021-01-13T11:00:00Z", "2021-03-18T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-05-04T23:15:00Z",
+  "updated": "2026-05-03T23:15:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.3,
   "linz:security_classification": "unclassified",

--- a/stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json
@@ -4909,12 +4909,6 @@
       "file:checksum": "12206b530f442708146b375f1c97489a6b838a3a2a34ddd6b0c79b89a430b12fd050"
     },
     {
-      "href": "./CA16_5000_0806.json",
-      "rel": "item",
-      "type": "application/geo+json",
-      "file:checksum": "1220534707948e531b19762dc296b8698d200eb5d5d6db13a0b51e679e5131b6588c"
-    },
-    {
       "href": "./CA16_5000_0901.json",
       "rel": "item",
       "type": "application/geo+json",
@@ -4962,7 +4956,7 @@
     "temporal": { "interval": [["2021-01-13T11:00:00Z", "2021-03-18T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-04-07T23:59:15Z",
+  "updated": "2026-05-04T23:15:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.3,
   "linz:security_classification": "unclassified",


### PR DESCRIPTION
### Motivation & Modifications

Remove the link to the `CA16_5000_0806` item from the `stac/canterbury/mackenzie_2021_0.3m/rgb/2193/collection.json` file, as it should not exist.