### PR TITLE
chore: backfill STAC metadata for urban aerial imagery TDE-1905

### DIFF
--- a/stac/auckland/auckland_2010-2011_0.125m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010-2011_0.125m/rgb/2193/collection.json
@@ -27670,6 +27670,6 @@
     "temporal": { "interval": [["2011-09-05T12:00:00Z", "2011-09-05T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/auckland/auckland_2010-2011_0.125m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010-2011_0.125m/rgb/2193/collection.json
@@ -27660,6 +27660,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "auckland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "auckland_2010-2011_0.125m",
   "extent": {
     "spatial": { "bbox": [[174.2377052, -37.2909366, 175.517143, -36.1465019]] },

--- a/stac/auckland/auckland_2010_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010_0.075m/rgb/2193/collection.json
@@ -2838,6 +2838,10 @@
     { "name": "Auckland Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "auckland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "auckland_2010_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.629357, -36.8388752, 174.8139454, -36.6576222]] },

--- a/stac/auckland/auckland_2010_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2010_0.075m/rgb/2193/collection.json
@@ -2848,6 +2848,6 @@
     "temporal": { "interval": [["2010-01-05T11:00:00Z", "2010-04-07T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/auckland/auckland_2012_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2012_0.075m/rgb/2193/collection.json
@@ -1138,6 +1138,6 @@
     "temporal": { "interval": [["2012-01-23T11:00:00Z", "2012-03-04T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/auckland/auckland_2012_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2012_0.075m/rgb/2193/collection.json
@@ -1128,6 +1128,10 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "auckland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "auckland_2012_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.5870215, -36.9619722, 175.0287917, -36.6114889]] },

--- a/stac/auckland/auckland_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2015-2016_0.075m/rgb/2193/collection.json
@@ -29038,6 +29038,6 @@
     "temporal": { "interval": [["2015-11-12T11:00:00Z", "2016-04-26T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/auckland/auckland_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2015-2016_0.075m/rgb/2193/collection.json
@@ -29028,6 +29028,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "auckland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "auckland_2015-2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.2564143, -37.2897725, 175.5226914, -36.139909]] },

--- a/stac/auckland/auckland_2017_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2017_0.075m/rgb/2193/collection.json
@@ -46824,6 +46824,10 @@
     { "name": "Auckland Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "auckland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "auckland_2017_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.2322456, -37.2897725, 175.5226914, -36.139909]] },

--- a/stac/auckland/auckland_2017_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2017_0.075m/rgb/2193/collection.json
@@ -46834,6 +46834,6 @@
     "temporal": { "interval": [["2017-03-14T11:00:00Z", "2017-05-05T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2010-2011_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2010-2011_0.125m/rgb/2193/collection.json
@@ -9391,6 +9391,10 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty_2010-2011_0.125m",
   "extent": {
     "spatial": { "bbox": [[176.031146, -38.468168, 177.1482548, -37.6205734]] },

--- a/stac/bay-of-plenty/bay-of-plenty_2010-2011_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2010-2011_0.125m/rgb/2193/collection.json
@@ -9401,6 +9401,6 @@
     "temporal": { "interval": [["2010-12-28T11:00:00Z", "2011-03-31T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.1m/rgb/2193/collection.json
@@ -372,6 +372,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty_2015-2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.8578196, -37.8707233, 176.2904584, -37.4193809]] },

--- a/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2015-2016_0.1m/rgb/2193/collection.json
@@ -382,6 +382,6 @@
     "temporal": { "interval": [["2016-01-08T11:00:00Z", "2016-04-13T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2018-2019_0.1m/rgb/2193/collection.json
@@ -13636,6 +13636,6 @@
     "temporal": { "interval": [["2018-07-11T12:00:00Z", "2019-01-16T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2018-2019_0.1m/rgb/2193/collection.json
@@ -13626,6 +13626,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty_2018-2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.8531345, -38.468168, 177.3035488, -37.3872422]] },

--- a/stac/bay-of-plenty/bay-of-plenty_2020_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2020_0.1m/rgb/2193/collection.json
@@ -28764,6 +28764,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty_2020_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.9812113, -37.8358253, 176.4738463, -37.6084886]] },

--- a/stac/bay-of-plenty/bay-of-plenty_2020_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2020_0.1m/rgb/2193/collection.json
@@ -28774,6 +28774,6 @@
     "temporal": { "interval": [["2020-12-15T11:00:00Z", "2020-12-15T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
@@ -18611,6 +18611,6 @@
     "temporal": { "interval": [["2022-07-31T12:00:00Z", "2022-08-04T12:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga-winter_2022_0.1m/rgb/2193/collection.json
@@ -18600,6 +18600,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tauranga-winter_2022_0.1m",
   "linz:geographic_description": "Tauranga Winter",
   "extent": {

--- a/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
@@ -4746,6 +4746,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tauranga_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.031146, -37.8256149, 176.4215671, -37.6140937]] },

--- a/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
@@ -4756,6 +4756,6 @@
     "temporal": { "interval": [["2017-03-20T11:00:00Z", "2017-03-20T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2017_0.1m/rgb/2193/collection.json
@@ -4748,6 +4748,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Tauranga",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
   "linz:slug": "tauranga_2017_0.1m",

--- a/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
@@ -19000,6 +19000,6 @@
     "temporal": { "interval": [["2022-01-17T11:00:00Z", "2022-01-17T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
@@ -18992,6 +18992,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Tauranga City",
   "linz:region": "bay-of-plenty",
   "linz:security_classification": "unclassified",
   "linz:slug": "tauranga_2022_0.1m",

--- a/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2022_0.1m/rgb/2193/collection.json
@@ -18990,6 +18990,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "bay-of-plenty",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tauranga_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.056766, -37.7948242, 176.4270065, -37.6206467]] },

--- a/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
@@ -31972,6 +31972,6 @@
     "temporal": { "interval": [["2020-01-15T11:00:00Z", "2020-01-16T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
@@ -31962,6 +31962,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "ashburton_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0307368, -44.2077101, 172.0610351, -43.5904192]] },

--- a/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2020_0.075m/rgb/2193/collection.json
@@ -31964,6 +31964,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Ashburton",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "ashburton_2020_0.075m",

--- a/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
@@ -18526,6 +18526,6 @@
     "temporal": { "interval": [["2021-11-04T11:00:00Z", "2022-01-01T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
@@ -18518,6 +18518,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Ashburton",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "ashburton_2021-2022_0.075m",

--- a/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2021-2022_0.075m/rgb/2193/collection.json
@@ -18516,6 +18516,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "ashburton_2021-2022_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0367883, -44.1917843, 172.2051486, -43.5126799]] },

--- a/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
@@ -10694,6 +10694,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Banks Peninsula",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "banks-peninsula_2019-2020_0.075m",

--- a/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
@@ -10692,6 +10692,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "banks-peninsula_2019-2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.6746125, -43.844809, 173.1013881, -43.6340198]] },

--- a/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2019-2020_0.075m/rgb/2193/collection.json
@@ -10702,6 +10702,6 @@
     "temporal": { "interval": [["2019-12-27T11:00:00Z", "2020-03-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
@@ -10737,6 +10737,6 @@
     "temporal": { "interval": [["2011-02-23T11:00:00Z", "2011-02-23T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
@@ -10727,6 +10727,10 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "christchurch-earthquake_2011_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.4819524, -43.8253912, 172.9940331, -43.331846]] },

--- a/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch-earthquake_2011_0.1m/rgb/2193/collection.json
@@ -10729,6 +10729,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Christchurch Post-Earthquake",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "christchurch-earthquake_2011_0.1m",

--- a/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
@@ -41986,6 +41986,6 @@
     "temporal": { "interval": [["2016-01-21T11:00:00Z", "2016-02-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
@@ -41976,6 +41976,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2015-2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3917526, -43.8350827, 173.1013443, -43.3877866]] },

--- a/stac/canterbury/christchurch_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2018-2019_0.075m/rgb/2193/collection.json
@@ -47922,6 +47922,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2018-2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.377018, -43.6822941, 172.8364487, -43.3776766]] },

--- a/stac/canterbury/christchurch_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2018-2019_0.075m/rgb/2193/collection.json
@@ -47932,6 +47932,6 @@
     "temporal": { "interval": [["2018-11-04T11:00:00Z", "2019-03-25T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2018_0.075m/rgb/2193/collection.json
@@ -616,6 +616,6 @@
     "temporal": { "interval": [["2018-01-13T11:00:00Z", "2018-01-13T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2018_0.075m/rgb/2193/collection.json
@@ -606,6 +606,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2018_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.6108301, -43.5428598, 172.6525502, -43.5200356]] },

--- a/stac/canterbury/christchurch_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2020-2021_0.075m/rgb/2193/collection.json
@@ -43774,6 +43774,6 @@
     "temporal": { "interval": [["2020-12-14T11:00:00Z", "2021-02-11T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2020-2021_0.075m/rgb/2193/collection.json
@@ -43764,6 +43764,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2020-2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3917851, -43.835085, 173.1043194, -43.3873534]] },

--- a/stac/canterbury/christchurch_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2021_0.05m/rgb/2193/collection.json
@@ -598,6 +598,6 @@
     "temporal": { "interval": [["2021-02-10T11:00:00Z", "2021-02-11T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/christchurch_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2021_0.05m/rgb/2193/collection.json
@@ -588,6 +588,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2021_0.05m",
   "extent": {
     "spatial": { "bbox": [[172.6108301, -43.5428598, 172.6525502, -43.5200656]] },

--- a/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
@@ -1718,6 +1718,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hurunui",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "hurunui_2013_0.125m",

--- a/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
@@ -1716,6 +1716,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hurunui_2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[172.7107171, -43.2059841, 172.7701423, -43.0471458]] },

--- a/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2013_0.125m/rgb/2193/collection.json
@@ -1726,6 +1726,6 @@
     "temporal": { "interval": [["2013-02-23T11:00:00Z", "2013-02-23T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
@@ -17752,6 +17752,6 @@
     "temporal": { "interval": [["2018-11-10T11:00:00Z", "2019-01-26T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
@@ -17744,6 +17744,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hurunui",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "hurunui_2018-2019_0.075m",

--- a/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/hurunui_2018-2019_0.075m/rgb/2193/collection.json
@@ -17742,6 +17742,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hurunui_2018-2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.5743037, -43.2509575, 173.4971847, -42.4669882]] },

--- a/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
@@ -16928,6 +16928,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Mackenzie",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "mackenzie_2020_0.075m",

--- a/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
@@ -16926,6 +16926,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "mackenzie_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[169.9177067, -44.2974718, 170.8928271, -43.9720456]] },

--- a/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/mackenzie_2020_0.075m/rgb/2193/collection.json
@@ -16936,6 +16936,6 @@
     "temporal": { "interval": [["2020-01-18T11:00:00Z", "2020-02-29T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
@@ -11848,6 +11848,6 @@
     "temporal": { "interval": [["2012-12-03T11:00:00Z", "2012-12-18T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
@@ -11838,6 +11838,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "selwyn_2012-2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[172.0616923, -43.8294982, 172.5741996, -43.4585793]] },

--- a/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2012-2013_0.125m/rgb/2193/collection.json
@@ -11840,6 +11840,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Selwyn",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "selwyn_2012-2013_0.125m",

--- a/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
@@ -22146,6 +22146,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "selwyn_2018-2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.5188866, -43.8975024, 172.5683607, -43.1763563]] },

--- a/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
@@ -22148,6 +22148,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Selwyn",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "selwyn_2018-2019_0.075m",

--- a/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2018-2019_0.075m/rgb/2193/collection.json
@@ -22156,6 +22156,6 @@
     "temporal": { "interval": [["2018-12-16T11:00:00Z", "2019-04-18T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
@@ -3114,6 +3114,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "selwyn_2019_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.5499206, -43.6007203, 172.5335176, -42.9248042]] },

--- a/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
@@ -3116,6 +3116,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Selwyn",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "selwyn_2019_0.075m",

--- a/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/selwyn_2019_0.075m/rgb/2193/collection.json
@@ -3124,6 +3124,6 @@
     "temporal": { "interval": [["2019-12-26T11:00:00Z", "2019-12-27T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
@@ -11832,6 +11832,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "timaru_2012-2013_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0995967, -44.5019645, 171.3136422, -44.0644391]] },

--- a/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
@@ -11834,6 +11834,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Timaru",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "timaru_2012-2013_0.075m",

--- a/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2012-2013_0.075m/rgb/2193/collection.json
@@ -11842,6 +11842,6 @@
     "temporal": { "interval": [["2012-11-13T11:00:00Z", "2012-12-03T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
@@ -17976,6 +17976,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "timaru_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0873653, -44.5116828, 171.3346752, -43.8802784]] },

--- a/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
@@ -17978,6 +17978,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Timaru",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "timaru_2020_0.075m",

--- a/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/timaru_2020_0.075m/rgb/2193/collection.json
@@ -17986,6 +17986,6 @@
     "temporal": { "interval": [["2020-01-17T11:00:00Z", "2020-01-17T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
@@ -11032,6 +11032,6 @@
     "temporal": { "interval": [["2013-11-12T11:00:00Z", "2013-12-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
@@ -11024,6 +11024,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waimakariri",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2013-2014_0.075m",

--- a/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2013-2014_0.075m/rgb/2193/collection.json
@@ -11022,6 +11022,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2013-2014_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.1477831, -43.4100443, 172.7308672, -43.2609631]] },

--- a/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
@@ -6714,6 +6714,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2015-2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[172.3518074, -43.3998127, 172.7100418, -43.2414248]] },

--- a/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
@@ -6716,6 +6716,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waimakariri",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2015-2016_0.075m",

--- a/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2015-2016_0.075m/rgb/2193/collection.json
@@ -6724,6 +6724,6 @@
     "temporal": { "interval": [["2016-01-21T11:00:00Z", "2016-01-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
@@ -14650,6 +14650,6 @@
     "temporal": { "interval": [["2021-01-02T11:00:00Z", "2021-02-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
@@ -14640,6 +14640,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2021_0.05m",
   "extent": {
     "spatial": { "bbox": [[172.144688, -43.4131444, 172.7367961, -43.2577293]] },

--- a/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2021_0.05m/rgb/2193/collection.json
@@ -14642,6 +14642,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waimakariri",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2021_0.05m",

--- a/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
@@ -2784,6 +2784,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2018_0.075m",
   "extent": {
     "spatial": { "bbox": [[171.0731488, -44.9345133, 171.2092172, -44.5109698]] },

--- a/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
@@ -2794,6 +2794,6 @@
     "temporal": { "interval": [["2018-11-05T11:00:00Z", "2018-12-23T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2018_0.075m/rgb/2193/collection.json
@@ -2786,6 +2786,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waimate",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2018_0.075m",

--- a/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
@@ -3592,6 +3592,6 @@
     "temporal": { "interval": [["2020-01-17T11:00:00Z", "2020-01-17T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
@@ -3582,6 +3582,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2020_0.075m",
   "extent": {
     "spatial": { "bbox": [[170.9908094, -44.7652759, 171.1022373, -44.7024341]] },

--- a/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2020_0.075m/rgb/2193/collection.json
@@ -3584,6 +3584,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waimate",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2020_0.075m",

--- a/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
@@ -6728,6 +6728,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waimate",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2021_0.075m",

--- a/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
@@ -6726,6 +6726,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[170.4720658, -44.9377021, 171.2092172, -44.5109698]] },

--- a/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2021_0.075m/rgb/2193/collection.json
@@ -6736,6 +6736,6 @@
     "temporal": { "interval": [["2021-11-30T11:00:00Z", "2021-11-30T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/gisborne/gisborne_2012_0.125m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2012_0.125m/rgb/2193/collection.json
@@ -917,6 +917,6 @@
     "temporal": { "interval": [["2012-01-04T11:00:00Z", "2012-03-14T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/gisborne/gisborne_2012_0.125m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2012_0.125m/rgb/2193/collection.json
@@ -907,6 +907,10 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "gisborne",
+  "linz:security_classification": "unclassified",
   "linz:slug": "gisborne_2012_0.125m",
   "extent": {
     "spatial": { "bbox": [[177.5291684, -38.7592481, 178.4173207, -37.5830715]] },

--- a/stac/gisborne/gisborne_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2017-2018_0.1m/rgb/2193/collection.json
@@ -11844,6 +11844,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "gisborne",
+  "linz:security_classification": "unclassified",
   "linz:slug": "gisborne_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.5284614, -38.7603087, 178.4177365, -37.5830296]] },

--- a/stac/gisborne/gisborne_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2017-2018_0.1m/rgb/2193/collection.json
@@ -11854,6 +11854,6 @@
     "temporal": { "interval": [["2017-03-30T11:00:00Z", "2018-02-15T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/gisborne/gisborne_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2022-2023_0.1m/rgb/2193/collection.json
@@ -11446,6 +11446,6 @@
     "temporal": { "interval": [["2022-02-14T11:00:00Z", "2023-02-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/gisborne/gisborne_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2022-2023_0.1m/rgb/2193/collection.json
@@ -11436,6 +11436,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "gisborne",
+  "linz:security_classification": "unclassified",
   "linz:slug": "gisborne_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.8233049, -38.7603087, 178.4177365, -37.5830296]] },

--- a/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
@@ -2398,6 +2398,6 @@
     "temporal": { "interval": [["2018-01-23T11:00:00Z", "2018-01-29T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
@@ -2390,6 +2390,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Central Hawke's Bay",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "linz:slug": "central-hawkes-bay_2017-2018_0.1m",

--- a/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/central-hawkes-bay_2017-2018_0.1m/rgb/2193/collection.json
@@ -2388,6 +2388,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "central-hawkes-bay_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.3125906, -40.4162834, 176.9333547, -39.8114584]] },

--- a/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
@@ -16586,6 +16586,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hastings District",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "linz:slug": "hastings-district_2014-2015_0.1m",

--- a/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
@@ -16594,6 +16594,6 @@
     "temporal": { "interval": [["2014-01-04T11:00:00Z", "2015-01-04T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings-district_2014-2015_0.1m/rgb/2193/collection.json
@@ -16584,6 +16584,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hastings-district_2014-2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.5960924, -39.866709, 177.0533949, -39.1229587]] },

--- a/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
@@ -5032,6 +5032,6 @@
     "temporal": { "interval": [["2018-01-24T11:00:00Z", "2018-01-30T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
@@ -5022,6 +5022,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hastings_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.6082676, -39.8337753, 177.0370161, -39.2828978]] },

--- a/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hastings_2017-2018_0.1m/rgb/2193/collection.json
@@ -5024,6 +5024,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hastings",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "linz:slug": "hastings_2017-2018_0.1m",

--- a/stac/hawkes-bay/hawkes-bay_2022_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2022_0.05m/rgb/2193/collection.json
@@ -2934,6 +2934,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hawkes-bay_2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[176.8275888, -39.560049, 176.9256871, -39.3992641]] },

--- a/stac/hawkes-bay/hawkes-bay_2022_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2022_0.05m/rgb/2193/collection.json
@@ -2944,6 +2944,6 @@
     "temporal": { "interval": [["2021-12-31T11:00:00Z", "2022-01-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/hawkes-bay_2022_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2022_0.1m/rgb/2193/collection.json
@@ -12846,6 +12846,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hawkes-bay_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.3122772, -40.4232862, 177.0370161, -39.2828978]] },

--- a/stac/hawkes-bay/hawkes-bay_2022_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2022_0.1m/rgb/2193/collection.json
@@ -12856,6 +12856,6 @@
     "temporal": { "interval": [["2021-12-31T11:00:00Z", "2022-01-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
@@ -1106,6 +1106,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Napier",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "linz:slug": "napier_2017-2018_0.05m",

--- a/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
@@ -1104,6 +1104,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "napier_2017-2018_0.05m",
   "extent": {
     "spatial": { "bbox": [[176.8095037, -39.5571074, 176.9239961, -39.4760956]] },

--- a/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.05m/rgb/2193/collection.json
@@ -1114,6 +1114,6 @@
     "temporal": { "interval": [["2018-01-19T11:00:00Z", "2018-01-29T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
@@ -8666,6 +8666,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Napier",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "linz:slug": "napier_2017-2018_0.1m",

--- a/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
@@ -8674,6 +8674,6 @@
     "temporal": { "interval": [["2018-01-24T11:00:00Z", "2018-01-30T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2017-2018_0.1m/rgb/2193/collection.json
@@ -8664,6 +8664,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "napier_2017-2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.8094564, -39.5743998, 176.927647, -39.3865041]] },

--- a/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
@@ -3104,6 +3104,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Wairoa",
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "linz:slug": "wairoa_2014-2015_0.1m",

--- a/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
@@ -3112,6 +3112,6 @@
     "temporal": { "interval": [["2014-12-21T11:00:00Z", "2015-12-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa_2014-2015_0.1m/rgb/2193/collection.json
@@ -3102,6 +3102,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
   "linz:slug": "wairoa_2014-2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[177.0112687, -39.132953, 177.9444863, -38.7907713]] },

--- a/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GYC6EZFJRX8J6KJ1RK79CEYM",
-  "title": "Manawatū 0.125m Urban Aerial Photos (2019)",
+  "title": "Manawatu 0.125m Urban Aerial Photos (2019)",
   "description": "Orthophotography within the Manawatū-Whanganui region captured in the 2019 flying season.",
   "license": "CC-BY-4.0",
   "links": [

--- a/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GYC6EZFJRX8J6KJ1RK79CEYM",
-  "title": "Manawatu 0.125m Urban Aerial Photos (2019)",
+  "title": "Manawatū 0.125m Urban Aerial Photos (2019)",
   "description": "Orthophotography within the Manawatū-Whanganui region captured in the 2019 flying season.",
   "license": "CC-BY-4.0",
   "links": [
@@ -7802,6 +7802,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Manawatū",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "manawatu_2019_0.125m",

--- a/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
@@ -7802,7 +7802,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
-  "linz:geographic_description": "Manawatū",
+  "linz:geographic_description": "Manawatu",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "manawatu_2019_0.125m",

--- a/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
@@ -7810,6 +7810,6 @@
     "temporal": { "interval": [["2019-01-28T11:00:00Z", "2019-02-02T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu_2019_0.125m/rgb/2193/collection.json
@@ -7800,6 +7800,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "manawatu_2019_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.2073285, -40.3997924, 175.8257914, -40.0370455]] },

--- a/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
@@ -3124,6 +3124,6 @@
     "temporal": { "interval": [["2012-12-19T11:00:00Z", "2012-12-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
@@ -3116,6 +3116,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Palmerston North",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2012-2013_0.125m",

--- a/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2012-2013_0.125m/rgb/2193/collection.json
@@ -3114,6 +3114,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2012-2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5386, -40.4245794, 175.7734202, -40.2711092]] },

--- a/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
@@ -6146,6 +6146,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Palmerston North",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2015_0.125m",

--- a/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
@@ -6144,6 +6144,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2015_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5101158, -40.4443971, 175.7959889, -40.2385783]] },

--- a/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2015_0.125m/rgb/2193/collection.json
@@ -6154,6 +6154,6 @@
     "temporal": { "interval": [["2015-02-11T11:00:00Z", "2015-02-17T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
@@ -6304,6 +6304,6 @@
     "temporal": { "interval": [["2017-02-28T11:00:00Z", "2017-04-09T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
@@ -6296,6 +6296,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Palmerston North",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2017_0.125m",

--- a/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2017_0.125m/rgb/2193/collection.json
@@ -6294,6 +6294,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2017_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5103564, -40.4506255, 175.7959889, -40.2383077]] },

--- a/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
@@ -6462,6 +6462,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2018_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5105971, -40.468661, 175.8008276, -40.2414826]] },

--- a/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
@@ -6464,6 +6464,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Palmerston North",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2018_0.125m",

--- a/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2018_0.125m/rgb/2193/collection.json
@@ -6472,6 +6472,6 @@
     "temporal": { "interval": [["2018-12-08T11:00:00Z", "2018-12-08T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
@@ -6412,6 +6412,6 @@
     "temporal": { "interval": [["2022-02-28T11:00:00Z", "2022-02-28T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
@@ -6404,6 +6404,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Palmerston North",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2022_0.125m",

--- a/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2022_0.125m/rgb/2193/collection.json
@@ -6402,6 +6402,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "palmerston-north_2022_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.5105971, -40.4685317, 175.80056, -40.2416114]] },

--- a/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
@@ -5724,6 +5724,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "rangitikei_2021_0.125m",
   "extent": {
     "spatial": { "bbox": [[175.1108251, -40.3149861, 175.86285, -39.628026]] },

--- a/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
@@ -5734,6 +5734,6 @@
     "temporal": { "interval": [["2020-08-31T12:00:00Z", "2021-04-29T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/rangitikei_2021_0.125m/rgb/2193/collection.json
@@ -5726,6 +5726,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Rangitīkei",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "rangitikei_2021_0.125m",

--- a/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
@@ -10606,6 +10606,6 @@
     "temporal": { "interval": [["2013-01-29T11:00:00Z", "2013-02-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
@@ -10598,6 +10598,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Whanganui",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "whanganui_2013_0.1m",

--- a/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2013_0.1m/rgb/2193/collection.json
@@ -10596,6 +10596,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "whanganui_2013_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.9256066, -39.9878699, 175.1229765, -39.8664782]] },

--- a/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
@@ -4164,6 +4164,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "whanganui_2015-2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.8800975, -39.9944022, 175.143911, -39.8433772]] },

--- a/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
@@ -4174,6 +4174,6 @@
     "temporal": { "interval": [["2015-08-26T12:00:00Z", "2015-08-26T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2015-2016_0.1m/rgb/2193/collection.json
@@ -4166,6 +4166,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Whanganui",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "whanganui_2015-2016_0.1m",

--- a/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
@@ -4612,6 +4612,6 @@
     "temporal": { "interval": [["2017-11-14T11:00:00Z", "2017-11-14T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
@@ -4602,6 +4602,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "manawatu-whanganui",
+  "linz:security_classification": "unclassified",
   "linz:slug": "whanganui_2017_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8744881, -39.9946971, 175.1495196, -39.8433772]] },

--- a/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2017_0.075m/rgb/2193/collection.json
@@ -4604,6 +4604,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Whanganui",
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "linz:slug": "whanganui_2017_0.075m",

--- a/stac/marlborough/marlborough_2017_0.1m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2017_0.1m/rgb/2193/collection.json
@@ -18240,6 +18240,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "marlborough",
+  "linz:security_classification": "unclassified",
   "linz:slug": "marlborough_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.4980367, -41.8456407, 174.1647442, -41.0475327]] },

--- a/stac/marlborough/marlborough_2017_0.1m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2017_0.1m/rgb/2193/collection.json
@@ -18250,6 +18250,6 @@
     "temporal": { "interval": [["2017-11-30T11:00:00Z", "2017-12-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/marlborough/marlborough_2020-2021_0.1m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2020-2021_0.1m/rgb/2193/collection.json
@@ -32172,6 +32172,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "marlborough",
+  "linz:security_classification": "unclassified",
   "linz:slug": "marlborough_2020-2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.4951828, -41.8521245, 174.167516, -41.0443091]] },

--- a/stac/marlborough/marlborough_2020-2021_0.1m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2020-2021_0.1m/rgb/2193/collection.json
@@ -32182,6 +32182,6 @@
     "temporal": { "interval": [["2020-10-15T11:00:00Z", "2021-01-14T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
@@ -20932,6 +20932,6 @@
     "temporal": { "interval": [["2023-10-22T11:00:00Z", "2023-11-22T11:00:00Z"]] }
   },
   "created": "2024-01-04T01:20:29Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.075m/rgb/2193/collection.json
@@ -20922,6 +20922,10 @@
     { "name": "Marlborough District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "marlborough",
+  "linz:security_classification": "unclassified",
   "linz:slug": "marlborough_2023_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.5122766, -41.8391007, 174.1619132, -41.0474557]] },

--- a/stac/nelson/nelson_2022_0.075m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2022_0.075m/rgb/2193/collection.json
@@ -6000,6 +6000,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "nelson",
+  "linz:security_classification": "unclassified",
   "linz:slug": "nelson_2022_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.1834789, -41.3934951, 173.5661143, -41.1006647]] },

--- a/stac/nelson/nelson_2022_0.075m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2022_0.075m/rgb/2193/collection.json
@@ -6010,6 +6010,6 @@
     "temporal": { "interval": [["2022-01-14T11:00:00Z", "2022-01-15T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/northland/northland_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2014-2015_0.1m/rgb/2193/collection.json
@@ -39328,6 +39328,6 @@
     "temporal": { "interval": [["2014-10-09T11:00:00Z", "2015-05-03T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/northland/northland_2014-2015_0.1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2014-2015_0.1m/rgb/2193/collection.json
@@ -39318,6 +39318,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "northland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "northland_2014-2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.1102017, -36.1749915, 174.6025874, -34.8008356]] },

--- a/stac/northland/northland_2016_0.1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2016_0.1m/rgb/2193/collection.json
@@ -19752,6 +19752,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "northland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "northland_2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.9004729, -36.3695389, 174.2640182, -34.609317]] },

--- a/stac/northland/northland_2016_0.1m/rgb/2193/collection.json
+++ b/stac/northland/northland_2016_0.1m/rgb/2193/collection.json
@@ -19762,6 +19762,6 @@
     "temporal": { "interval": [["2016-03-19T11:00:00Z", "2016-07-01T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
@@ -7430,6 +7430,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Dunedin",
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:slug": "dunedin_2013_0.125m",

--- a/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
@@ -7438,6 +7438,6 @@
     "temporal": { "interval": [["2013-01-21T11:00:00Z", "2013-01-31T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2013_0.125m/rgb/2193/collection.json
@@ -7428,6 +7428,10 @@
     { "name": "Dunedin City Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "otago",
+  "linz:security_classification": "unclassified",
   "linz:slug": "dunedin_2013_0.125m",
   "extent": {
     "spatial": { "bbox": [[170.1016142, -45.9649081, 170.7406305, -45.2896267]] },

--- a/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
@@ -8250,6 +8250,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "otago",
+  "linz:security_classification": "unclassified",
   "linz:slug": "dunedin_2018-2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[170.1016142, -46.0275569, 170.746538, -45.2896267]] },

--- a/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
@@ -8260,6 +8260,6 @@
     "temporal": { "interval": [["2018-01-13T11:00:00Z", "2019-04-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
+++ b/stac/otago/dunedin_2018-2019_0.1m/rgb/2193/collection.json
@@ -8252,6 +8252,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Dunedin",
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:slug": "dunedin_2018-2019_0.1m",

--- a/stac/otago/otago_2018_0.1m/rgb/2193/collection.json
+++ b/stac/otago/otago_2018_0.1m/rgb/2193/collection.json
@@ -5406,6 +5406,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "otago",
+  "linz:security_classification": "unclassified",
   "linz:slug": "otago_2018_0.1m",
   "extent": {
     "spatial": { "bbox": [[169.1141488, -45.5686336, 170.1679453, -44.9494545]] },

--- a/stac/otago/otago_2018_0.1m/rgb/2193/collection.json
+++ b/stac/otago/otago_2018_0.1m/rgb/2193/collection.json
@@ -5416,6 +5416,6 @@
     "temporal": { "interval": [["2018-01-14T11:00:00Z", "2018-01-28T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
@@ -1014,6 +1014,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "otago",
+  "linz:security_classification": "unclassified",
   "linz:slug": "queenstown-lakes_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[169.0918736, -44.7568136, 169.2893251, -44.6062695]] },

--- a/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
@@ -1024,6 +1024,6 @@
     "temporal": { "interval": [["2022-12-06T11:00:00Z", "2023-01-25T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown-lakes_2022-2023_0.1m/rgb/2193/collection.json
@@ -1016,6 +1016,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Queenstown Lakes",
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:slug": "queenstown-lakes_2022-2023_0.1m",

--- a/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
@@ -3006,6 +3006,10 @@
     { "name": "Queenstown-Lakes District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "otago",
+  "linz:security_classification": "unclassified",
   "linz:slug": "queenstown_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[168.6167982, -45.1078028, 168.863241, -44.9339579]] },

--- a/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
@@ -3016,6 +3016,6 @@
     "temporal": { "interval": [["2021-03-12T11:00:00Z", "2021-03-13T11:00:00Z"]] }
   },
   "created": "2023-09-28T03:37:19Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
+++ b/stac/otago/queenstown_2021_0.1m/rgb/2193/collection.json
@@ -3008,6 +3008,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Queenstown",
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "linz:slug": "queenstown_2021_0.1m",

--- a/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
@@ -3086,6 +3086,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Invercargill",
   "linz:region": "southland",
   "linz:security_classification": "unclassified",
   "linz:slug": "invercargill_2016_0.05m",

--- a/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
@@ -3084,6 +3084,10 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "southland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "invercargill_2016_0.05m",
   "extent": {
     "spatial": { "bbox": [[168.3178948, -46.6153242, 168.4043712, -46.3681297]] },

--- a/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.05m/rgb/2193/collection.json
@@ -3094,6 +3094,6 @@
     "temporal": { "interval": [["2016-02-06T11:00:00Z", "2016-02-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
@@ -10188,6 +10188,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "southland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "invercargill_2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[168.1916795, -46.6279865, 168.5441519, -46.287563]] },

--- a/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
@@ -10198,6 +10198,6 @@
     "temporal": { "interval": [["2016-02-06T11:00:00Z", "2016-02-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2016_0.1m/rgb/2193/collection.json
@@ -10190,6 +10190,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Invercargill",
   "linz:region": "southland",
   "linz:security_classification": "unclassified",
   "linz:slug": "invercargill_2016_0.1m",

--- a/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
@@ -5486,6 +5486,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Invercargill",
   "linz:region": "southland",
   "linz:security_classification": "unclassified",
   "linz:slug": "invercargill_2022_0.05m",

--- a/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
@@ -5484,6 +5484,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "southland",
+  "linz:security_classification": "unclassified",
   "linz:slug": "invercargill_2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[168.2531261, -46.6153242, 168.4611922, -46.355213]] },

--- a/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
+++ b/stac/southland/invercargill_2022_0.05m/rgb/2193/collection.json
@@ -5494,6 +5494,6 @@
     "temporal": { "interval": [["2022-02-20T11:00:00Z", "2022-03-18T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
@@ -12608,6 +12608,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "New Plymouth",
   "linz:region": "taranaki",
   "linz:security_classification": "unclassified",
   "linz:slug": "new-plymouth_2017_0.1m",

--- a/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
@@ -12606,6 +12606,10 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "taranaki",
+  "linz:security_classification": "unclassified",
   "linz:slug": "new-plymouth_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.8614872, -39.2013367, 174.6007638, -38.8141385]] },

--- a/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/new-plymouth_2017_0.1m/rgb/2193/collection.json
@@ -12616,6 +12616,6 @@
     "temporal": { "interval": [["2017-04-07T12:00:00Z", "2017-04-07T12:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/taranaki/taranaki_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022-2023_0.05m/rgb/2193/collection.json
@@ -2682,6 +2682,10 @@
     { "name": "Taranaki Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "taranaki",
+  "linz:security_classification": "unclassified",
   "linz:slug": "taranaki_2022-2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[173.7973698, -39.5503032, 174.8601595, -38.9760619]] },

--- a/stac/taranaki/taranaki_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022-2023_0.05m/rgb/2193/collection.json
@@ -2692,6 +2692,6 @@
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-04-29T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/taranaki/taranaki_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022-2023_0.1m/rgb/2193/collection.json
@@ -5112,6 +5112,10 @@
     { "name": "Taranaki Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "taranaki",
+  "linz:security_classification": "unclassified",
   "linz:slug": "taranaki_2022-2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.7729585, -39.8694428, 174.7537975, -39.139632]] },

--- a/stac/taranaki/taranaki_2022-2023_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022-2023_0.1m/rgb/2193/collection.json
@@ -5122,6 +5122,6 @@
     "temporal": { "interval": [["2022-09-30T11:00:00Z", "2023-04-29T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/taranaki/taranaki_2022_0.05m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022_0.05m/rgb/2193/collection.json
@@ -214,6 +214,6 @@
     "temporal": { "interval": [["2022-01-07T11:00:00Z", "2022-03-22T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/taranaki/taranaki_2022_0.05m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022_0.05m/rgb/2193/collection.json
@@ -204,6 +204,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "taranaki",
+  "linz:security_classification": "unclassified",
   "linz:slug": "taranaki_2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[174.4436952, -39.8354095, 174.6380232, -39.6593424]] },

--- a/stac/taranaki/taranaki_2022_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022_0.1m/rgb/2193/collection.json
@@ -17920,6 +17920,6 @@
     "temporal": { "interval": [["2022-01-07T11:00:00Z", "2022-03-22T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/taranaki/taranaki_2022_0.1m/rgb/2193/collection.json
+++ b/stac/taranaki/taranaki_2022_0.1m/rgb/2193/collection.json
@@ -17910,6 +17910,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "taranaki",
+  "linz:security_classification": "unclassified",
   "linz:slug": "taranaki_2022_0.1m",
   "extent": {
     "spatial": { "bbox": [[173.8614872, -39.6256825, 174.6007638, -38.8141385]] },

--- a/stac/tasman/tasman_2017_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2017_0.075m/rgb/2193/collection.json
@@ -490,6 +490,6 @@
     "temporal": { "interval": [["2017-11-19T11:00:00Z", "2017-11-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/tasman/tasman_2017_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2017_0.075m/rgb/2193/collection.json
@@ -480,6 +480,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "tasman",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tasman_2017_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.1434283, -41.3678217, 173.2180539, -41.3158805]] },

--- a/stac/tasman/tasman_2017_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2017_0.1m/rgb/2193/collection.json
@@ -1818,6 +1818,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "tasman",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tasman_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.3122997, -41.8135051, 173.1263047, -40.6734161]] },

--- a/stac/tasman/tasman_2017_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2017_0.1m/rgb/2193/collection.json
@@ -1828,6 +1828,6 @@
     "temporal": { "interval": [["2017-11-16T11:00:00Z", "2017-11-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/tasman/tasman_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020-2021_0.075m/rgb/2193/collection.json
@@ -1018,6 +1018,6 @@
     "temporal": { "interval": [["2020-10-15T11:00:00Z", "2021-01-14T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/tasman/tasman_2020-2021_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020-2021_0.075m/rgb/2193/collection.json
@@ -1008,6 +1008,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "tasman",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tasman_2020-2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[173.126217, -41.3743274, 173.2295531, -41.3093127]] },

--- a/stac/tasman/tasman_2020_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020_0.1m/rgb/2193/collection.json
@@ -6354,6 +6354,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "tasman",
+  "linz:security_classification": "unclassified",
   "linz:slug": "tasman_2020_0.1m",
   "extent": {
     "spatial": { "bbox": [[172.300672, -41.82012, 173.1435423, -40.6668243]] },

--- a/stac/tasman/tasman_2020_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2020_0.1m/rgb/2193/collection.json
@@ -6364,6 +6364,6 @@
     "temporal": { "interval": [["2020-10-15T11:00:00Z", "2020-10-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
@@ -2980,6 +2980,6 @@
     "temporal": { "interval": [["2015-03-19T11:00:00Z", "2015-03-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
@@ -2970,6 +2970,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2015_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.1773614, -37.8551303, 175.3601519, -37.6818198]] },

--- a/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2015_0.1m/rgb/2193/collection.json
@@ -2972,6 +2972,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hamilton",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2015_0.1m",

--- a/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
@@ -5580,6 +5580,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2016-2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.1661045, -37.8685235, 175.3846497, -37.6687483]] },

--- a/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
@@ -5582,6 +5582,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hamilton",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2016-2017_0.1m",

--- a/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2016-2017_0.1m/rgb/2193/collection.json
@@ -5590,6 +5590,6 @@
     "temporal": { "interval": [["2017-01-03T11:00:00Z", "2017-02-05T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
@@ -8850,6 +8850,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },

--- a/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
@@ -8860,6 +8860,6 @@
     "temporal": { "interval": [["2019-03-19T11:00:00Z", "2019-03-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2019_0.1m/rgb/2193/collection.json
@@ -8852,6 +8852,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hamilton",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2019_0.1m",

--- a/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
@@ -8840,6 +8840,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hamilton",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2020-2021_0.05m",

--- a/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
@@ -8848,6 +8848,6 @@
     "temporal": { "interval": [["2020-12-27T11:00:00Z", "2021-01-29T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2020-2021_0.05m/rgb/2193/collection.json
@@ -8838,6 +8838,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2020-2021_0.05m",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },

--- a/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
@@ -636,6 +636,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "taupo_2019_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.7184284, -38.9684906, 175.7934701, -38.7146977]] },

--- a/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
@@ -646,6 +646,6 @@
     "temporal": { "interval": [["2018-12-17T11:00:00Z", "2019-01-03T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2019_0.1m/rgb/2193/collection.json
@@ -638,6 +638,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Taupō",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "taupo_2019_0.1m",

--- a/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
@@ -1004,6 +1004,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Taupō",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "taupo_2021_0.1m",

--- a/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
@@ -1002,6 +1002,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "taupo_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.7519779, -39.0056729, 176.2961344, -38.3509748]] },

--- a/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/taupo_2021_0.1m/rgb/2193/collection.json
@@ -1012,6 +1012,6 @@
     "temporal": { "interval": [["2021-01-25T11:00:00Z", "2021-01-25T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-04-10T00:00:00Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
@@ -3882,6 +3882,10 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waikato-district_2014_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.7080652, -37.8415177, 175.3991154, -37.2243943]] },

--- a/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
@@ -3884,6 +3884,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waikato District",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "waikato-district_2014_0.1m",

--- a/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato-district_2014_0.1m/rgb/2193/collection.json
@@ -3892,6 +3892,6 @@
     "temporal": { "interval": [["2014-01-09T11:00:00Z", "2014-03-06T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
@@ -464,6 +464,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waikato District",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "waikato_2021-2022_0.05m",

--- a/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
@@ -462,6 +462,10 @@
     { "name": "Recon", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waikato_2021-2022_0.05m",
   "extent": {
     "spatial": { "bbox": [[174.8591255, -37.8045678, 175.2160185, -37.2243607]] },

--- a/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2022_0.05m/rgb/2193/collection.json
@@ -472,6 +472,6 @@
     "temporal": { "interval": [["2021-02-25T11:00:00Z", "2022-05-05T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/waikato_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021_0.1m/rgb/2193/collection.json
@@ -5692,6 +5692,6 @@
     "temporal": { "interval": [["2021-01-25T11:00:00Z", "2021-03-22T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/waikato/waikato_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021_0.1m/rgb/2193/collection.json
@@ -5682,6 +5682,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waikato_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.7023515, -37.8550235, 175.4160939, -37.2109235]] },

--- a/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
@@ -17352,6 +17352,10 @@
     { "name": "Landpro", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "waikato",
+  "linz:security_classification": "unclassified",
   "linz:slug": "waipa_2021_0.1m",
   "extent": {
     "spatial": { "bbox": [[175.0694451, -38.1531959, 175.6996572, -37.7952575]] },

--- a/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
@@ -17354,6 +17354,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Waipa",
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "linz:slug": "waipa_2021_0.1m",

--- a/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
+++ b/stac/waikato/waipa_2021_0.1m/rgb/2193/collection.json
@@ -17362,6 +17362,6 @@
     "temporal": { "interval": [["2021-01-30T11:00:00Z", "2021-02-18T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
@@ -2120,6 +2120,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Carterton",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "carterton_2021_0.075m",

--- a/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
@@ -2128,6 +2128,6 @@
     "temporal": { "interval": [["2021-01-04T11:00:00Z", "2021-01-24T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/carterton_2021_0.075m/rgb/2193/collection.json
@@ -2118,6 +2118,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "carterton_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.487309, -41.2490246, 175.9617072, -40.9559098]] },

--- a/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
@@ -7314,6 +7314,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hutt-city_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.8468393, -41.3193504, 175.0026514, -41.1429728]] },

--- a/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
@@ -7324,6 +7324,6 @@
     "temporal": { "interval": [["2017-02-27T11:00:00Z", "2017-03-04T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2017_0.1m/rgb/2193/collection.json
@@ -7316,6 +7316,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hutt City",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "hutt-city_2017_0.1m",

--- a/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
@@ -7340,6 +7340,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Hutt City",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "hutt-city_2021_0.075m",

--- a/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
@@ -7348,6 +7348,6 @@
     "temporal": { "interval": [["2021-01-12T11:00:00Z", "2021-01-26T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/hutt-city_2021_0.075m/rgb/2193/collection.json
@@ -7338,6 +7338,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "hutt-city_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8468393, -41.3193504, 175.0026514, -41.1429728]] },

--- a/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
@@ -16128,6 +16128,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "kapiti-coast_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.9290902, -41.0140691, 175.2151345, -40.699395]] },

--- a/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
@@ -16138,6 +16138,6 @@
     "temporal": { "interval": [["2017-02-23T11:00:00Z", "2017-02-23T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2017_0.1m/rgb/2193/collection.json
@@ -16130,6 +16130,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Kapiti Coast",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "kapiti-coast_2017_0.1m",

--- a/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
@@ -16138,6 +16138,6 @@
     "temporal": { "interval": [["2021-01-13T11:00:00Z", "2021-01-13T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
@@ -16130,6 +16130,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Kapiti Coast",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "kapiti-coast_2021_0.075m",

--- a/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/kapiti-coast_2021_0.075m/rgb/2193/collection.json
@@ -16128,6 +16128,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "kapiti-coast_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.9290902, -41.0140691, 175.2151345, -40.699395]] },

--- a/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
@@ -6448,6 +6448,6 @@
     "temporal": { "interval": [["2021-01-03T11:00:00Z", "2021-01-24T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
@@ -6438,6 +6438,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "masterton_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.5561002, -41.1066377, 176.2684264, -40.7719414]] },

--- a/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/masterton_2021_0.075m/rgb/2193/collection.json
@@ -6440,6 +6440,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Masterton",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "masterton_2021_0.075m",

--- a/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
@@ -1522,6 +1522,6 @@
     "temporal": { "interval": [["2016-01-31T11:00:00Z", "2016-03-05T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
@@ -1514,6 +1514,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Porirua",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "porirua_2016_0.075m",

--- a/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2016_0.075m/rgb/2193/collection.json
@@ -1512,6 +1512,10 @@
     { "name": "AAM NZ", "roles": ["licensor", "producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "porirua_2016_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.8064258, -41.1721178, 174.9267893, -41.0213641]] },

--- a/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
@@ -10022,6 +10022,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Porirua",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "porirua_2020_0.1m",

--- a/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
@@ -10030,6 +10030,6 @@
     "temporal": { "interval": [["2020-02-24T11:00:00Z", "2020-02-24T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2020_0.1m/rgb/2193/collection.json
@@ -10020,6 +10020,10 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "porirua_2020_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.797855, -41.1754935, 174.9331697, -41.017981]] },

--- a/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
@@ -4598,6 +4598,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "South Wairarapa",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "south-wairarapa_2021_0.075m",

--- a/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
@@ -4606,6 +4606,6 @@
     "temporal": { "interval": [["2021-01-04T11:00:00Z", "2021-01-24T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/south-wairarapa_2021_0.075m/rgb/2193/collection.json
@@ -4596,6 +4596,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "south-wairarapa_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[175.1442312, -41.6052017, 175.5093756, -41.0510807]] },

--- a/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
@@ -2688,6 +2688,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "upper-hutt_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.9905276, -41.1783229, 175.1491, -41.0827532]] },

--- a/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
@@ -2698,6 +2698,6 @@
     "temporal": { "interval": [["2017-02-27T11:00:00Z", "2017-02-27T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2017_0.1m/rgb/2193/collection.json
@@ -2690,6 +2690,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Upper Hutt",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "upper-hutt_2017_0.1m",

--- a/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
@@ -2706,6 +2706,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "upper-hutt_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.9905276, -41.1783229, 175.1491, -41.0827532]] },

--- a/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
@@ -2716,6 +2716,6 @@
     "temporal": { "interval": [["2021-01-24T11:00:00Z", "2021-01-26T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/upper-hutt_2021_0.075m/rgb/2193/collection.json
@@ -2708,6 +2708,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Upper Hutt",
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "linz:slug": "upper-hutt_2021_0.075m",

--- a/stac/wellington/wellington_2012-2013_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2012-2013_0.1m/rgb/2193/collection.json
@@ -9748,6 +9748,6 @@
     "temporal": { "interval": [["2012-12-12T11:00:00Z", "2013-01-05T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/wellington_2012-2013_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2012-2013_0.1m/rgb/2193/collection.json
@@ -9738,6 +9738,10 @@
     { "name": "New Zealand Aerial Mapping", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "wellington_2012-2013_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.6964075, -41.3648867, 174.8641026, -41.1488854]] },

--- a/stac/wellington/wellington_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2017_0.1m/rgb/2193/collection.json
@@ -10020,6 +10020,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "wellington_2017_0.1m",
   "extent": {
     "spatial": { "bbox": [[174.6924387, -41.3648867, 174.8641026, -41.1488854]] },

--- a/stac/wellington/wellington_2017_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2017_0.1m/rgb/2193/collection.json
@@ -10030,6 +10030,6 @@
     "temporal": { "interval": [["2017-02-23T11:00:00Z", "2017-03-04T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/wellington/wellington_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2021_0.075m/rgb/2193/collection.json
@@ -12138,6 +12138,10 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "wellington",
+  "linz:security_classification": "unclassified",
   "linz:slug": "wellington_2021_0.075m",
   "extent": {
     "spatial": { "bbox": [[174.6961558, -41.3681707, 174.8670568, -41.1456442]] },

--- a/stac/wellington/wellington_2021_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2021_0.075m/rgb/2193/collection.json
@@ -12148,6 +12148,6 @@
     "temporal": { "interval": [["2021-01-12T11:00:00Z", "2021-01-12T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
+++ b/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
@@ -3596,6 +3596,7 @@
   ],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "urban-aerial-photos",
+  "linz:geographic_description": "Buller",
   "linz:region": "west-coast",
   "linz:security_classification": "unclassified",
   "linz:slug": "buller_2020_0.2m",

--- a/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
+++ b/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
@@ -3594,6 +3594,10 @@
     { "name": "Buller District Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "west-coast",
+  "linz:security_classification": "unclassified",
   "linz:slug": "buller_2020_0.2m",
   "extent": {
     "spatial": { "bbox": [[171.3214966, -42.1343457, 172.2267458, -41.1048994]] },

--- a/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
+++ b/stac/west-coast/buller_2020_0.2m/rgb/2193/collection.json
@@ -3604,6 +3604,6 @@
     "temporal": { "interval": [["2020-05-14T12:00:00Z", "2020-10-14T11:00:00Z"]] }
   },
   "created": "2024-01-04T01:14:41Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/west-coast/west-coast_2016_0.1m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_2016_0.1m/rgb/2193/collection.json
@@ -5956,6 +5956,6 @@
     "temporal": { "interval": [["2016-12-19T11:00:00Z", "2016-12-19T11:00:00Z"]] }
   },
   "created": "2024-01-04T00:58:57Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-05T00:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/west-coast/west-coast_2016_0.1m/rgb/2193/collection.json
+++ b/stac/west-coast/west-coast_2016_0.1m/rgb/2193/collection.json
@@ -5946,6 +5946,10 @@
     { "name": "West Coast Regional Council", "roles": ["licensor"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "urban-aerial-photos",
+  "linz:region": "west-coast",
+  "linz:security_classification": "unclassified",
   "linz:slug": "west-coast_2016_0.1m",
   "extent": {
     "spatial": { "bbox": [[171.4403681, -42.1474067, 171.908972, -41.6854255]] },


### PR DESCRIPTION
**Motivation & Modifications**
To ensure the metadata is complete and aligned with the documentation, backfill all the missing collection STAC metadata in the urban aerial imagery.