### PR TITLE
chore: backfill metadata on miscellaneous datasets TDE-1905

### DIFF
--- a/stac/canterbury/kaikoura-earthquake_2016-2017_0.3m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura-earthquake_2016-2017_0.3m/rgb/2193/collection.json
@@ -2,8 +2,8 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01GYB46Y9YXBNDAE94T4E41G08",
-  "title": "Kaikoura 0.3m Rural Aerial Photos (2016-2017)",
-  "description": "Orthophotography within the Canterbury region captured in the 2016-2017 flying season, published as a record of the Kaikoura Earthquake event.",
+  "title": "Kaikōura 0.3m Rural Aerial Photos (2016-2017)",
+  "description": "Orthophotography within the Canterbury region captured in the 2016-2017 flying season, published as a record of the Kaikōura Earthquake event.",
   "license": "CC-BY-4.0",
   "links": [
     {
@@ -9905,7 +9905,7 @@
     "temporal": { "interval": [["2016-12-19T11:00:00Z", "2017-02-23T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-05-03T20:16:02Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.3,
   "linz:security_classification": "unclassified",

--- a/stac/canterbury/kaikoura-earthquake_2016_0.2m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura-earthquake_2016_0.2m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01H0HJNREMVEVH5R51Y4WGFRWE",
-  "title": "Kaikoura Earthquake 0.2m Aerial Photos (2016)",
+  "title": "Kaikōura Earthquake 0.2m Aerial Photos (2016)",
   "description": "Orthophotography within the Canterbury region captured in the 2016 flying season.",
   "license": "CC-BY-4.0",
   "links": [
@@ -3534,12 +3534,18 @@
     { "name": "AAM NZ", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "rural-aerial-photos",
+  "linz:geographic_description": "Kaikōura",
+  "linz:region": "canterbury",
+  "linz:security_classification": "unclassified",
+  "linz:event_name": "Kaikōura Earthquake",
   "linz:slug": "kaikoura-earthquake_2016_0.2m",
   "extent": {
     "spatial": { "bbox": [[173.2638486, -42.7358876, 173.9472199, -42.1616646]] },
     "temporal": { "interval": [["2016-11-13T11:00:00Z", "2016-11-13T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/canterbury/kaikoura_2016-2017_0.3m/rgbnir/2193/collection.json
+++ b/stac/canterbury/kaikoura_2016-2017_0.3m/rgbnir/2193/collection.json
@@ -2,8 +2,8 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01KQR1XT9K0RZHR4SEG0G1W45P",
-  "title": "Kaikoura 0.3m Near-Infrared Aerial Photos (2016-2017)",
-  "description": "Near-infrared orthophotography within the Canterbury region captured in the 2016-2017 flying season, published as a record of the Kaikoura Earthquake event.",
+  "title": "Kaikōura 0.3m Near-Infrared Aerial Photos (2016-2017)",
+  "description": "Near-infrared orthophotography within the Canterbury region captured in the 2016-2017 flying season, published as a record of the Kaikōura Earthquake event.",
   "license": "CC-BY-4.0",
   "links": [
     {
@@ -2712,7 +2712,7 @@
   "linz:slug": "kaikoura_2016-2017_0.3m",
   "gsd": 0.3,
   "created": "2026-05-03T23:14:12Z",
-  "updated": "2026-05-03T23:14:12Z",
+  "updated": "2026-05-06T03:00:00Z",
   "linz:event_name": "Kaikōura Earthquake",
   "linz:geographic_description": "Kaikōura",
   "extent": {

--- a/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
@@ -2,7 +2,7 @@
   "type": "Collection",
   "stac_version": "1.0.0",
   "id": "01J4GVCC82ZYV2J5Y01BN1JH25",
-  "title": "Kaikoura 0.05m Urban Aerial Photos (2023)",
+  "title": "Kaikōura 0.05m Urban Aerial Photos (2023)",
   "description": "Orthophotography within the Canterbury region captured in the 2023 flying season.",
   "license": "CC-BY-4.0",
   "links": [
@@ -654,8 +654,8 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "created": "2024-08-06T23:40:05Z",
-  "updated": "2024-11-14T01:59:24Z",
-  "linz:geographic_description": "Kaikoura",
+  "updated": "2026-05-06T03:00:00Z",
+  "linz:geographic_description": "Kaikōura",
   "linz:slug": "kaikoura_2023_0.05m",
   "extent": {
     "spatial": { "bbox": [[173.6386994, -42.4261794, 173.7088714, -42.3710316]] },

--- a/stac/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay-cyclone-gabrielle_2023_0.1m/rgb/2193/collection.json
@@ -36978,12 +36978,17 @@
     { "name": "SKYCAN", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "aerial-photos",
+  "linz:region": "hawkes-bay",
+  "linz:security_classification": "unclassified",
+  "linz:event_name": "Cyclone Gabrielle",
   "linz:slug": "hawkes-bay-cyclone-gabrielle_2023_0.1m",
   "extent": {
     "spatial": { "bbox": [[176.3097734, -40.0558183, 177.4773044, -38.8693573]] },
     "temporal": { "interval": [["2023-02-18T11:00:00Z", "2023-02-20T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/nelson/top-of-the-south-flood_2022_0.15m/rgb/2193/collection.json
+++ b/stac/nelson/top-of-the-south-flood_2022_0.15m/rgb/2193/collection.json
@@ -31916,12 +31916,17 @@
     { "name": "Aerial Surveys", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "aerial-photos",
+  "linz:region": "nelson",
+  "linz:security_classification": "unclassified",
+  "linz:event_name": "Top of the South Flood",
   "linz:slug": "top-of-the-south-flood_2022_0.15m",
   "extent": {
     "spatial": { "bbox": [[172.7779619, -41.5039845, 173.6804067, -40.7970765]] },
     "temporal": { "interval": [["2022-08-22T12:00:00Z", "2022-09-05T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/new-zealand/north-island_20221122_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_20221122_10m/rgb/2193/collection.json
@@ -977,12 +977,17 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "European Space Agency", "roles": ["producer"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "satellite-imagery",
+  "linz:geographic_description": "North Island",
+  "linz:region": "new-zealand",
+  "linz:security_classification": "unclassified",
   "linz:slug": "north-island_20221122_10m",
   "extent": {
     "spatial": { "bbox": [[173.4291746, -41.8210614, 178.3861945, -36.5982342]] },
     "temporal": { "interval": [["2022-11-21T11:00:00Z", "2022-11-21T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/new-zealand/north-island_20230220_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_20230220_10m/rgb/2193/collection.json
@@ -977,12 +977,18 @@
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["licensor", "host", "processor"] },
     { "name": "European Space Agency", "roles": ["producer"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "satellite-imagery",
+  "linz:geographic_description": "North Island",
+  "linz:region": "new-zealand",
+  "linz:security_classification": "unclassified",
+  "linz:event_name": "Cyclone Gabrielle",
   "linz:slug": "north-island_20230220_10m",
   "extent": {
     "spatial": { "bbox": [[173.4170765, -41.8065264, 178.6357959, -35.9498962]] },
     "temporal": { "interval": [["2022-02-19T11:00:00Z", "2022-02-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }

--- a/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
@@ -1884,12 +1884,18 @@
     { "name": "Chang Guang Satellite Technology", "roles": ["producer"] },
     { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] }
   ],
+  "linz:lifecycle": "completed",
+  "linz:geospatial_category": "satellite-imagery",
+  "linz:geographic_description": "North Island",
+  "linz:region": "new-zealand",
+  "linz:security_classification": "unclassified",
+  "linz:event_name": "Cyclone Gabrielle",
   "linz:slug": "north-island_2023_0.5m",
   "extent": {
     "spatial": { "bbox": [[175.2700705, -41.6259979, 178.5669558, -37.5202786]] },
     "temporal": { "interval": [["2023-02-20T11:00:00Z", "2023-03-07T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-05-06T03:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
 }


### PR DESCRIPTION
**Motivation & Modifications**
To ensure the metadata is complete and aligned with the documentation, backfill all the missing collection STAC metadata in aerial imagery associated with events.
Also add macrons to older Kaikōura datasets for consistency.