### PR TITLE
fix: add LINZ as a licensor for crown scanned imagery

### DIFF
--- a/stac/auckland/auckland_sn1283_1960_0.25m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn1283_1960_0.25m/rgb/2193/collection.json
@@ -428,7 +428,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -439,7 +439,7 @@
   "linz:slug": "auckland_sn1283_1960_0.25m",
   "gsd": 0.25,
   "created": "2025-06-03T03:46:59Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:29Z",
   "linz:historic_survey_number": "SN1283",
   "extent": {
     "spatial": { "bbox": [[175.2677418, -36.3784411, 175.5683906, -36.0228458]] },

--- a/stac/auckland/auckland_sn1397_1961-1963_0.25m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn1397_1961-1963_0.25m/rgb/2193/collection.json
@@ -1892,7 +1892,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1903,7 +1903,7 @@
   "linz:slug": "auckland_sn1397_1961-1963_0.25m",
   "gsd": 0.25,
   "created": "2025-06-10T03:29:49Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:29Z",
   "linz:historic_survey_number": "SN1397",
   "extent": {
     "spatial": { "bbox": [[174.5389722, -37.7829735, 175.5342014, -37.0716752]] },

--- a/stac/auckland/auckland_sn1397_1961-1963_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn1397_1961-1963_0.4m/rgb/2193/collection.json
@@ -1232,7 +1232,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1243,7 +1243,7 @@
   "linz:slug": "auckland_sn1397_1961-1963_0.4m",
   "gsd": 0.4,
   "created": "2025-06-09T02:54:20Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:29Z",
   "linz:historic_survey_number": "SN1397",
   "extent": {
     "spatial": { "bbox": [[174.6234069, -37.5536125, 175.3897381, -37.2312146]] },

--- a/stac/auckland/auckland_sn139_1939-1940_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn139_1939-1940_0.4m/rgb/2193/collection.json
@@ -938,7 +938,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -949,7 +949,7 @@
   "linz:slug": "auckland_sn139_1939-1940_0.4m",
   "gsd": 0.4,
   "created": "2025-05-30T04:02:27Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:29Z",
   "linz:historic_survey_number": "SN139",
   "extent": {
     "spatial": { "bbox": [[174.6972984, -37.1045252, 175.3224607, -36.8052982]] },

--- a/stac/auckland/auckland_sn1411_1961_0.06m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn1411_1961_0.06m/rgb/2193/collection.json
@@ -542,7 +542,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -553,7 +553,7 @@
   "linz:slug": "auckland_sn1411_1961_0.06m",
   "gsd": 0.06,
   "created": "2025-06-06T03:47:24Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:29Z",
   "linz:historic_survey_number": "SN1411",
   "extent": {
     "spatial": { "bbox": [[174.8709341, -37.2332527, 174.9315415, -37.1677809]] },

--- a/stac/auckland/auckland_sn143_1940-1941_0.32m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn143_1940-1941_0.32m/rgb/2193/collection.json
@@ -1238,7 +1238,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1249,7 +1249,7 @@
   "linz:slug": "auckland_sn143_1940-1941_0.32m",
   "gsd": 0.32,
   "created": "2025-05-30T04:46:13Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:29Z",
   "linz:historic_survey_number": "SN143",
   "extent": {
     "spatial": { "bbox": [[174.1790735, -36.8504776, 174.9054873, -36.4890171]] },

--- a/stac/auckland/auckland_sn144_1940_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn144_1940_0.375m/rgb/2193/collection.json
@@ -236,7 +236,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -247,7 +247,7 @@
   "linz:slug": "auckland_sn144_1940_0.375m",
   "gsd": 0.375,
   "created": "2025-05-30T04:46:13Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN144",
   "extent": {
     "spatial": { "bbox": [[174.9094956, -36.8730821, 175.2348494, -36.740942]] },

--- a/stac/auckland/auckland_sn146_1940_0.24m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn146_1940_0.24m/rgb/2193/collection.json
@@ -4292,7 +4292,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -4303,7 +4303,7 @@
   "linz:slug": "auckland_sn146_1940_0.24m",
   "gsd": 0.24,
   "created": "2025-05-30T04:57:36Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN146",
   "extent": {
     "spatial": { "bbox": [[174.6587524, -36.9508071, 174.8859586, -36.8308115]] },

--- a/stac/auckland/auckland_sn147_1940-1949_0.32m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn147_1940-1949_0.32m/rgb/2193/collection.json
@@ -458,7 +458,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -469,7 +469,7 @@
   "linz:slug": "auckland_sn147_1940-1949_0.32m",
   "gsd": 0.32,
   "created": "2025-05-30T05:07:04Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN147",
   "extent": {
     "spatial": { "bbox": [[174.3992574, -37.076588, 174.7249595, -36.8145643]] },

--- a/stac/auckland/auckland_sn160_1940_0.32m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn160_1940_0.32m/rgb/2193/collection.json
@@ -122,7 +122,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -133,7 +133,7 @@
   "linz:slug": "auckland_sn160_1940_0.32m",
   "gsd": 0.32,
   "created": "2025-06-03T23:35:11Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN160",
   "extent": {
     "spatial": { "bbox": [[174.8012091, -36.8126012, 175.0153164, -36.6794113]] },

--- a/stac/auckland/auckland_sn189_1942_0.32m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn189_1942_0.32m/rgb/2193/collection.json
@@ -212,7 +212,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -223,7 +223,7 @@
   "linz:slug": "auckland_sn189_1942_0.32m",
   "gsd": 0.32,
   "created": "2025-06-03T01:47:55Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN189",
   "extent": {
     "spatial": { "bbox": [[175.2677418, -36.2838676, 175.5118034, -36.150908]] },

--- a/stac/auckland/auckland_sn192_1942-1954_0.32m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn192_1942-1954_0.32m/rgb/2193/collection.json
@@ -920,7 +920,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -931,7 +931,7 @@
   "linz:slug": "auckland_sn192_1942-1954_0.32m",
   "gsd": 0.32,
   "created": "2025-06-05T02:39:39Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN192",
   "extent": {
     "spatial": { "bbox": [[174.4567576, -37.3018864, 175.1633078, -37.0059593]] },

--- a/stac/auckland/auckland_sn2714_1974_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2714_1974_0.04m/rgb/2193/collection.json
@@ -248,7 +248,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -259,7 +259,7 @@
   "linz:slug": "auckland_sn2714_1974_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T04:26:18Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN2714",
   "extent": {
     "spatial": { "bbox": [[174.7268393, -36.8329464, 174.7650757, -36.7809667]] },

--- a/stac/auckland/auckland_sn2717_1974_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2717_1974_0.04m/rgb/2193/collection.json
@@ -896,7 +896,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -907,7 +907,7 @@
   "linz:slug": "auckland_sn2717_1974_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T04:29:23Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN2717",
   "extent": {
     "spatial": { "bbox": [[174.734413, -36.9075132, 174.7744932, -36.8617421]] },

--- a/stac/auckland/auckland_sn2751_1974-1975_0.08m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2751_1974-1975_0.08m/rgb/2193/collection.json
@@ -2690,7 +2690,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -2701,7 +2701,7 @@
   "linz:slug": "auckland_sn2751_1974-1975_0.08m",
   "gsd": 0.08,
   "created": "2025-06-03T04:45:39Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN2751",
   "extent": {
     "spatial": { "bbox": [[174.6479854, -36.9376796, 174.895767, -36.8263797]] },

--- a/stac/auckland/auckland_sn2802_1975_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2802_1975_0.04m/rgb/2193/collection.json
@@ -578,7 +578,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -589,7 +589,7 @@
   "linz:slug": "auckland_sn2802_1975_0.04m",
   "gsd": 0.04,
   "created": "2025-06-09T02:02:05Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:30Z",
   "linz:historic_survey_number": "SN2802",
   "extent": {
     "spatial": { "bbox": [[174.7079259, -36.943627, 174.7836244, -36.8847674]] },

--- a/stac/auckland/auckland_sn2863_1975_0.15m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2863_1975_0.15m/rgb/2193/collection.json
@@ -176,7 +176,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -187,7 +187,7 @@
   "linz:slug": "auckland_sn2863_1975_0.15m",
   "gsd": 0.15,
   "created": "2025-06-03T05:20:58Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN2863",
   "extent": {
     "spatial": { "bbox": [[174.7041072, -37.2812817, 174.7705154, -37.2156188]] },

--- a/stac/auckland/auckland_sn2883_1975-1976_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2883_1975-1976_0.04m/rgb/2193/collection.json
@@ -596,7 +596,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -607,7 +607,7 @@
   "linz:slug": "auckland_sn2883_1975-1976_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T05:27:25Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN2883",
   "extent": {
     "spatial": { "bbox": [[174.7139189, -36.7680704, 174.7746361, -36.6834939]] },

--- a/stac/auckland/auckland_sn2970_1976_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2970_1976_0.375m/rgb/2193/collection.json
@@ -602,7 +602,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -613,7 +613,7 @@
   "linz:slug": "auckland_sn2970_1976_0.375m",
   "gsd": 0.375,
   "created": "2025-06-09T02:02:05Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN2970",
   "extent": {
     "spatial": { "bbox": [[174.4261587, -37.076923, 174.7526441, -36.7168668]] },

--- a/stac/auckland/auckland_sn2975_1977-1978_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn2975_1977-1978_0.75m/rgb/2193/collection.json
@@ -266,7 +266,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -277,7 +277,7 @@
   "linz:slug": "auckland_sn2975_1977-1978_0.75m",
   "gsd": 0.75,
   "created": "2025-10-01T02:51:39Z",
-  "updated": "2025-10-01T02:51:39Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN2975",
   "extent": {
     "spatial": { "bbox": [[174.7519006, -37.1295713, 175.3504479, -36.6765767]] },

--- a/stac/auckland/auckland_sn347_1947_0.125m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn347_1947_0.125m/rgb/2193/collection.json
@@ -1910,7 +1910,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1921,7 +1921,7 @@
   "linz:slug": "auckland_sn347_1947_0.125m",
   "gsd": 0.125,
   "created": "2025-06-05T02:57:20Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN347",
   "extent": {
     "spatial": { "bbox": [[174.6700847, -36.9478331, 174.9029223, -36.8899539]] },

--- a/stac/auckland/auckland_sn3800_1975_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn3800_1975_0.75m/rgb/2193/collection.json
@@ -1004,7 +1004,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1015,7 +1015,7 @@
   "linz:slug": "auckland_sn3800_1975_0.75m",
   "gsd": 0.75,
   "created": "2025-06-03T06:12:11Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN3800",
   "extent": {
     "spatial": { "bbox": [[174.1503643, -37.5277898, 175.1417951, -36.3652934]] },

--- a/stac/auckland/auckland_sn5015_1976_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5015_1976_0.75m/rgb/2193/collection.json
@@ -542,7 +542,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -553,7 +553,7 @@
   "linz:slug": "auckland_sn5015_1976_0.75m",
   "gsd": 0.75,
   "created": "2025-10-01T02:51:16Z",
-  "updated": "2025-10-01T02:51:16Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN5015",
   "extent": {
     "spatial": { "bbox": [[174.1475118, -36.6236831, 174.9023038, -36.1004862]] },

--- a/stac/auckland/auckland_sn50393c_2004_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn50393c_2004_0.375m/rgb/2193/collection.json
@@ -1370,7 +1370,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1381,7 +1381,7 @@
   "linz:slug": "auckland_sn50393c_2004_0.375m",
   "gsd": 0.375,
   "created": "2025-06-04T03:43:09Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN50393C",
   "extent": {
     "spatial": { "bbox": [[174.3637691, -36.8180345, 174.9323115, -36.3264244]] },

--- a/stac/auckland/auckland_sn5275_1978-1979_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5275_1978-1979_0.04m/rgb/2193/collection.json
@@ -1178,7 +1178,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1189,7 +1189,7 @@
   "linz:slug": "auckland_sn5275_1978-1979_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T06:31:57Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN5275",
   "extent": {
     "spatial": { "bbox": [[174.6584018, -36.6516809, 174.8463176, -36.5848835]] },

--- a/stac/auckland/auckland_sn5296_1978_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5296_1978_0.04m/rgb/2193/collection.json
@@ -476,7 +476,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -487,7 +487,7 @@
   "linz:slug": "auckland_sn5296_1978_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T06:33:19Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:31Z",
   "linz:historic_survey_number": "SN5296",
   "extent": {
     "spatial": { "bbox": [[174.6729237, -36.8271593, 174.7490862, -36.7750263]] },

--- a/stac/auckland/auckland_sn5308_1978-1979_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5308_1978-1979_0.75m/rgb/2193/collection.json
@@ -464,7 +464,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -475,7 +475,7 @@
   "linz:slug": "auckland_sn5308_1978-1979_0.75m",
   "gsd": 0.75,
   "created": "2025-06-03T07:30:31Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5308",
   "extent": {
     "spatial": { "bbox": [[174.4261587, -37.1369603, 175.0804543, -36.488223]] },

--- a/stac/auckland/auckland_sn5414_1979_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5414_1979_0.05m/rgb/2193/collection.json
@@ -296,7 +296,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -307,7 +307,7 @@
   "linz:slug": "auckland_sn5414_1979_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T07:40:59Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5414",
   "extent": {
     "spatial": { "bbox": [[174.4177916, -36.6943016, 174.4720981, -36.6486857]] },

--- a/stac/auckland/auckland_sn5615c_1979_0.6m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5615c_1979_0.6m/rgb/2193/collection.json
@@ -38,7 +38,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -49,7 +49,7 @@
   "linz:slug": "auckland_sn5615c_1979_0.6m",
   "gsd": 0.6,
   "created": "2025-06-03T08:00:47Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5615C",
   "extent": {
     "spatial": { "bbox": [[175.0011049, -36.2892865, 175.1628784, -36.1576674]] },

--- a/stac/auckland/auckland_sn5645_1980_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5645_1980_0.05m/rgb/2193/collection.json
@@ -98,7 +98,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -109,7 +109,7 @@
   "linz:slug": "auckland_sn5645_1980_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T08:03:26Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5645",
   "extent": {
     "spatial": { "bbox": [[174.689036, -36.5545919, 174.7162656, -36.5348211]] },

--- a/stac/auckland/auckland_sn5646_1980_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5646_1980_0.05m/rgb/2193/collection.json
@@ -206,7 +206,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -217,7 +217,7 @@
   "linz:slug": "auckland_sn5646_1980_0.05m",
   "gsd": 0.05,
   "created": "2025-06-06T02:04:44Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5646",
   "extent": {
     "spatial": { "bbox": [[174.6377902, -36.4189407, 174.6810111, -36.3862764]] },

--- a/stac/auckland/auckland_sn5652_1980_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5652_1980_0.05m/rgb/2193/collection.json
@@ -398,7 +398,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -409,7 +409,7 @@
   "linz:slug": "auckland_sn5652_1980_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T08:19:23Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5652",
   "extent": {
     "spatial": { "bbox": [[174.6735157, -36.6196999, 174.7230687, -36.5544389]] },

--- a/stac/auckland/auckland_sn5707_1980_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5707_1980_0.05m/rgb/2193/collection.json
@@ -152,7 +152,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -163,7 +163,7 @@
   "linz:slug": "auckland_sn5707_1980_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T08:26:26Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5707",
   "extent": {
     "spatial": { "bbox": [[174.6173271, -36.9838451, 174.6500816, -36.9511086]] },

--- a/stac/auckland/auckland_sn5717_1980_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5717_1980_0.05m/rgb/2193/collection.json
@@ -314,7 +314,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -325,7 +325,7 @@
   "linz:slug": "auckland_sn5717_1980_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T08:35:05Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5717",
   "extent": {
     "spatial": { "bbox": [[174.8270231, -36.9743698, 174.8758228, -36.9219698]] },

--- a/stac/auckland/auckland_sn577_1951-1960_0.3m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn577_1951-1960_0.3m/rgb/2193/collection.json
@@ -2144,7 +2144,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -2155,7 +2155,7 @@
   "linz:slug": "auckland_sn577_1951-1960_0.3m",
   "gsd": 0.3,
   "created": "2025-06-06T03:14:31Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN577",
   "extent": {
     "spatial": { "bbox": [[173.9615271, -36.7216231, 174.9054873, -36.2309952]] },

--- a/stac/auckland/auckland_sn5783_1980-1981_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5783_1980-1981_0.4m/rgb/2193/collection.json
@@ -2396,7 +2396,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -2407,7 +2407,7 @@
   "linz:slug": "auckland_sn5783_1980-1981_0.4m",
   "gsd": 0.4,
   "created": "2025-06-03T08:39:59Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:32Z",
   "linz:historic_survey_number": "SN5783",
   "extent": {
     "spatial": { "bbox": [[174.1522813, -37.1086871, 175.2357953, -36.4878169]] },

--- a/stac/auckland/auckland_sn583_1950-1960_0.25m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn583_1950-1960_0.25m/rgb/2193/collection.json
@@ -2054,7 +2054,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -2065,7 +2065,7 @@
   "linz:slug": "auckland_sn583_1950-1960_0.25m",
   "gsd": 0.25,
   "created": "2025-06-06T02:34:56Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN583",
   "extent": {
     "spatial": { "bbox": [[174.3157789, -37.1385616, 175.3234516, -36.6508168]] },

--- a/stac/auckland/auckland_sn5840_1981_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5840_1981_0.05m/rgb/2193/collection.json
@@ -272,7 +272,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -283,7 +283,7 @@
   "linz:slug": "auckland_sn5840_1981_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T08:54:37Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN5840",
   "extent": {
     "spatial": { "bbox": [[174.7268393, -36.8329464, 174.7650757, -36.7809667]] },

--- a/stac/auckland/auckland_sn5841_1981_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn5841_1981_0.05m/rgb/2193/collection.json
@@ -206,7 +206,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -217,7 +217,7 @@
   "linz:slug": "auckland_sn5841_1981_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T09:03:28Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN5841",
   "extent": {
     "spatial": { "bbox": [[174.73965, -36.9043881, 174.7719515, -36.8584984]] },

--- a/stac/auckland/auckland_sn8083_1982_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8083_1982_0.05m/rgb/2193/collection.json
@@ -554,7 +554,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -565,7 +565,7 @@
   "linz:slug": "auckland_sn8083_1982_0.05m",
   "gsd": 0.05,
   "created": "2025-06-03T09:12:38Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8083",
   "extent": {
     "spatial": { "bbox": [[174.809942, -36.9420173, 174.8750281, -36.8768962]] },

--- a/stac/auckland/auckland_sn8162_1983_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8162_1983_0.375m/rgb/2193/collection.json
@@ -122,7 +122,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -133,7 +133,7 @@
   "linz:slug": "auckland_sn8162_1983_0.375m",
   "gsd": 0.375,
   "created": "2025-06-03T09:16:53Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8162",
   "extent": {
     "spatial": { "bbox": [[174.8042523, -36.9423471, 174.994346, -36.8429204]] },

--- a/stac/auckland/auckland_sn8211_1983_0.08m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8211_1983_0.08m/rgb/2193/collection.json
@@ -650,7 +650,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -661,7 +661,7 @@
   "linz:slug": "auckland_sn8211_1983_0.08m",
   "gsd": 0.08,
   "created": "2025-06-03T09:21:54Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8211",
   "extent": {
     "spatial": { "bbox": [[174.6292197, -36.839036, 174.8248598, -36.6966273]] },

--- a/stac/auckland/auckland_sn8485_1985_0.1m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8485_1985_0.1m/rgb/2193/collection.json
@@ -374,7 +374,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -385,7 +385,7 @@
   "linz:slug": "auckland_sn8485_1985_0.1m",
   "gsd": 0.1,
   "created": "2025-06-12T05:50:08Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8485",
   "extent": {
     "spatial": { "bbox": [[174.5770642, -36.8802598, 174.6750446, -36.7625859]] },

--- a/stac/auckland/auckland_sn8608_1986_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8608_1986_0.04m/rgb/2193/collection.json
@@ -602,7 +602,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -613,7 +613,7 @@
   "linz:slug": "auckland_sn8608_1986_0.04m",
   "gsd": 0.04,
   "created": "2025-06-05T09:02:42Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8608",
   "extent": {
     "spatial": { "bbox": [[174.7026845, -36.943627, 174.7837755, -36.8907743]] },

--- a/stac/auckland/auckland_sn8772_1987-1988_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8772_1987-1988_0.4m/rgb/2193/collection.json
@@ -2396,7 +2396,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -2407,7 +2407,7 @@
   "linz:slug": "auckland_sn8772_1987-1988_0.4m",
   "gsd": 0.4,
   "created": "2025-06-05T09:30:39Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8772",
   "extent": {
     "spatial": { "bbox": [[174.1518009, -37.1086871, 175.2357953, -36.4307405]] },

--- a/stac/auckland/auckland_sn8824_1991_0.24m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8824_1991_0.24m/rgb/2193/collection.json
@@ -434,7 +434,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -445,7 +445,7 @@
   "linz:slug": "auckland_sn8824_1991_0.24m",
   "gsd": 0.24,
   "created": "2025-06-03T10:31:49Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:33Z",
   "linz:historic_survey_number": "SN8824",
   "extent": {
     "spatial": { "bbox": [[174.5993973, -36.9323089, 174.7085048, -36.8146396]] },

--- a/stac/auckland/auckland_sn8906_1988_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8906_1988_0.04m/rgb/2193/collection.json
@@ -266,7 +266,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -277,7 +277,7 @@
   "linz:slug": "auckland_sn8906_1988_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T10:36:51Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN8906",
   "extent": {
     "spatial": { "bbox": [[174.7268393, -36.8329464, 174.7649268, -36.7809667]] },

--- a/stac/auckland/auckland_sn8930_1988_0.08m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn8930_1988_0.08m/rgb/2193/collection.json
@@ -146,7 +146,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -157,7 +157,7 @@
   "linz:slug": "auckland_sn8930_1988_0.08m",
   "gsd": 0.08,
   "created": "2025-06-03T10:41:58Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN8930",
   "extent": {
     "spatial": { "bbox": [[174.6010237, -36.984066, 174.687241, -36.9311155]] },

--- a/stac/auckland/auckland_sn9005_1989_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9005_1989_0.05m/rgb/2193/collection.json
@@ -1304,7 +1304,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1315,7 +1315,7 @@
   "linz:slug": "auckland_sn9005_1989_0.05m",
   "gsd": 0.05,
   "created": "2025-06-05T10:16:21Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9005",
   "extent": {
     "spatial": { "bbox": [[174.6585408, -36.6516809, 174.8461629, -36.5347439]] },

--- a/stac/auckland/auckland_sn9025c_1989_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9025c_1989_0.375m/rgb/2193/collection.json
@@ -176,7 +176,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -187,7 +187,7 @@
   "linz:slug": "auckland_sn9025c_1989_0.375m",
   "gsd": 0.375,
   "created": "2025-06-03T11:05:07Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9025C",
   "extent": {
     "spatial": { "bbox": [[175.0499557, -37.1329976, 175.2135711, -36.9679422]] },

--- a/stac/auckland/auckland_sn9026c_1989_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9026c_1989_0.375m/rgb/2193/collection.json
@@ -446,7 +446,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -457,7 +457,7 @@
   "linz:slug": "auckland_sn9026c_1989_0.375m",
   "gsd": 0.375,
   "created": "2025-06-03T11:10:53Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9026C",
   "extent": {
     "spatial": { "bbox": [[174.3711989, -37.076923, 174.6739194, -36.7514924]] },

--- a/stac/auckland/auckland_sn9055_1989_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9055_1989_0.04m/rgb/2193/collection.json
@@ -134,7 +134,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -145,7 +145,7 @@
   "linz:slug": "auckland_sn9055_1989_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T11:21:37Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9055",
   "extent": {
     "spatial": { "bbox": [[174.4813478, -36.6352451, 174.5140485, -36.6090887]] },

--- a/stac/auckland/auckland_sn9056_1989_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9056_1989_0.04m/rgb/2193/collection.json
@@ -128,7 +128,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -139,7 +139,7 @@
   "linz:slug": "auckland_sn9056_1989_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T11:32:06Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9056",
   "extent": {
     "spatial": { "bbox": [[174.640111, -36.5228271, 174.6780357, -36.5029898]] },

--- a/stac/auckland/auckland_sn9057_1989_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9057_1989_0.04m/rgb/2193/collection.json
@@ -116,7 +116,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -127,7 +127,7 @@
   "linz:slug": "auckland_sn9057_1989_0.04m",
   "gsd": 0.04,
   "created": "2025-06-03T11:42:25Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9057",
   "extent": {
     "spatial": { "bbox": [[174.7008617, -36.3661311, 174.7281676, -36.3400247]] },

--- a/stac/auckland/auckland_sn9059_1989_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9059_1989_0.04m/rgb/2193/collection.json
@@ -278,7 +278,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -289,7 +289,7 @@
   "linz:slug": "auckland_sn9059_1989_0.04m",
   "gsd": 0.04,
   "created": "2025-06-05T03:36:26Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9059",
   "extent": {
     "spatial": { "bbox": [[174.7021336, -36.443757, 174.7566604, -36.3983406]] },

--- a/stac/auckland/auckland_sn9140_1991_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9140_1991_0.04m/rgb/2193/collection.json
@@ -476,7 +476,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -487,7 +487,7 @@
   "linz:slug": "auckland_sn9140_1991_0.04m",
   "gsd": 0.04,
   "created": "2025-06-05T02:19:05Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9140",
   "extent": {
     "spatial": { "bbox": [[174.4176727, -36.7072141, 174.4828401, -36.6486857]] },

--- a/stac/auckland/auckland_sn9150_1991_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9150_1991_0.4m/rgb/2193/collection.json
@@ -344,7 +344,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -355,7 +355,7 @@
   "linz:slug": "auckland_sn9150_1991_0.4m",
   "gsd": 0.4,
   "created": "2025-06-03T12:17:55Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:34Z",
   "linz:historic_survey_number": "SN9150",
   "extent": {
     "spatial": { "bbox": [[174.8334985, -37.1685566, 175.0804543, -36.9393293]] },

--- a/stac/auckland/auckland_sn9151_1991_0.4m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9151_1991_0.4m/rgb/2193/collection.json
@@ -548,7 +548,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -559,7 +559,7 @@
   "linz:slug": "auckland_sn9151_1991_0.4m",
   "gsd": 0.4,
   "created": "2025-06-03T12:25:57Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9151",
   "extent": {
     "spatial": { "bbox": [[174.4261587, -37.0444819, 174.7526441, -36.7168668]] },

--- a/stac/auckland/auckland_sn9152_1991_0.1m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9152_1991_0.1m/rgb/2193/collection.json
@@ -470,7 +470,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -481,7 +481,7 @@
   "linz:slug": "auckland_sn9152_1991_0.1m",
   "gsd": 0.1,
   "created": "2025-06-03T12:35:44Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9152",
   "extent": {
     "spatial": { "bbox": [[174.6010237, -36.984212, 174.6977299, -36.8144887]] },

--- a/stac/auckland/auckland_sn9179_1991_0.1m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9179_1991_0.1m/rgb/2193/collection.json
@@ -344,7 +344,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -355,7 +355,7 @@
   "linz:slug": "auckland_sn9179_1991_0.1m",
   "gsd": 0.1,
   "created": "2025-06-03T12:54:33Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9179",
   "extent": {
     "spatial": { "bbox": [[174.8939147, -37.1221121, 175.0034766, -37.0179738]] },

--- a/stac/auckland/auckland_sn9206_1992_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9206_1992_0.04m/rgb/2193/collection.json
@@ -386,7 +386,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -397,7 +397,7 @@
   "linz:slug": "auckland_sn9206_1992_0.04m",
   "gsd": 0.04,
   "created": "2025-06-05T01:35:01Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9206",
   "extent": {
     "spatial": { "bbox": [[174.637518, -36.425355, 174.6918547, -36.3732251]] },

--- a/stac/auckland/auckland_sn9274_1993_0.15m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9274_1993_0.15m/rgb/2193/collection.json
@@ -1412,7 +1412,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1423,7 +1423,7 @@
   "linz:slug": "auckland_sn9274_1993_0.15m",
   "gsd": 0.15,
   "created": "2025-06-11T02:13:02Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9274",
   "extent": {
     "spatial": { "bbox": [[174.7513067, -37.1093141, 174.9822256, -36.8368691]] },

--- a/stac/auckland/auckland_sn9283_1993_0.1m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9283_1993_0.1m/rgb/2193/collection.json
@@ -1166,7 +1166,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1177,7 +1177,7 @@
   "linz:slug": "auckland_sn9283_1993_0.1m",
   "gsd": 0.1,
   "created": "2025-06-11T01:39:01Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9283",
   "extent": {
     "spatial": { "bbox": [[174.6419076, -36.9811057, 174.90115, -36.8260611]] },

--- a/stac/auckland/auckland_sn9349_1994_0.15m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9349_1994_0.15m/rgb/2193/collection.json
@@ -1310,7 +1310,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1321,7 +1321,7 @@
   "linz:slug": "auckland_sn9349_1994_0.15m",
   "gsd": 0.15,
   "created": "2025-06-11T01:38:55Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9349",
   "extent": {
     "spatial": { "bbox": [[174.6209303, -36.9812703, 174.9119159, -36.8259003]] },

--- a/stac/auckland/auckland_sn9359_1994_0.15m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9359_1994_0.15m/rgb/2193/collection.json
@@ -1544,7 +1544,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1555,7 +1555,7 @@
   "linz:slug": "auckland_sn9359_1994_0.15m",
   "gsd": 0.15,
   "created": "2025-06-11T02:24:59Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9359",
   "extent": {
     "spatial": { "bbox": [[174.5663029, -36.9578199, 174.8248598, -36.6833349]] },

--- a/stac/auckland/auckland_sn9394_1994_0.04m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9394_1994_0.04m/rgb/2193/collection.json
@@ -170,7 +170,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -181,7 +181,7 @@
   "linz:slug": "auckland_sn9394_1994_0.04m",
   "gsd": 0.04,
   "created": "2025-06-11T01:58:20Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9394",
   "extent": {
     "spatial": { "bbox": [[174.5754688, -36.7768121, 174.608126, -36.7440112]] },

--- a/stac/auckland/auckland_sn9578_1996_0.2m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9578_1996_0.2m/rgb/2193/collection.json
@@ -452,7 +452,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -463,7 +463,7 @@
   "linz:slug": "auckland_sn9578_1996_0.2m",
   "gsd": 0.2,
   "created": "2025-06-11T02:41:39Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:35Z",
   "linz:historic_survey_number": "SN9578",
   "extent": {
     "spatial": { "bbox": [[174.658124, -36.6708334, 174.8414158, -36.5413861]] },

--- a/stac/auckland/auckland_sn9907c_2000_0.1m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9907c_2000_0.1m/rgb/2193/collection.json
@@ -1184,7 +1184,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1195,7 +1195,7 @@
   "linz:slug": "auckland_sn9907c_2000_0.1m",
   "gsd": 0.1,
   "created": "2025-06-03T13:15:25Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:historic_survey_number": "SN9907C",
   "extent": {
     "spatial": { "bbox": [[174.6421851, -36.9682959, 174.9122395, -36.8255759]] },

--- a/stac/auckland/auckland_sn9909c_2000_0.1m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9909c_2000_0.1m/rgb/2193/collection.json
@@ -1160,7 +1160,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1171,7 +1171,7 @@
   "linz:slug": "auckland_sn9909c_2000_0.1m",
   "gsd": 0.1,
   "created": "2025-06-05T01:45:42Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:historic_survey_number": "SN9909C",
   "extent": {
     "spatial": { "bbox": [[174.62703, -36.8521709, 174.8248598, -36.6447255]] },

--- a/stac/auckland/auckland_sn9938_2000_0.75m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9938_2000_0.75m/rgb/2193/collection.json
@@ -914,7 +914,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -925,7 +925,7 @@
   "linz:slug": "auckland_sn9938_2000_0.75m",
   "gsd": 0.75,
   "created": "2025-06-11T02:46:08Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:historic_survey_number": "SN9938",
   "extent": {
     "spatial": { "bbox": [[174.4297883, -37.398821, 175.1417951, -36.423345]] },

--- a/stac/auckland/auckland_sn9959_2000_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9959_2000_0.375m/rgb/2193/collection.json
@@ -1058,7 +1058,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -1069,7 +1069,7 @@
   "linz:slug": "auckland_sn9959_2000_0.375m",
   "gsd": 0.375,
   "created": "2025-06-11T02:50:02Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:historic_survey_number": "SN9959",
   "extent": {
     "spatial": { "bbox": [[174.3928167, -36.8829206, 174.7227703, -36.2947607]] },

--- a/stac/auckland/auckland_sn9998c_2001_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9998c_2001_0.075m/rgb/2193/collection.json
@@ -536,7 +536,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -547,7 +547,7 @@
   "linz:slug": "auckland_sn9998c_2001_0.075m",
   "gsd": 0.075,
   "created": "2025-06-04T03:28:41Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:historic_survey_number": "SN9998C",
   "extent": {
     "spatial": { "bbox": [[174.4229217, -36.7137027, 174.477966, -36.642197]] },

--- a/stac/auckland/auckland_sn9999c_2001_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_sn9999c_2001_0.075m/rgb/2193/collection.json
@@ -494,7 +494,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -505,7 +505,7 @@
   "linz:slug": "auckland_sn9999c_2001_0.075m",
   "gsd": 0.075,
   "created": "2025-06-04T03:28:41Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:historic_survey_number": "SN9999C",
   "extent": {
     "spatial": { "bbox": [[174.6373819, -36.4319174, 174.6866432, -36.3666619]] },

--- a/stac/auckland/auckland_waikato_sn348_1944_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_waikato_sn348_1944_0.375m/rgb/2193/collection.json
@@ -476,7 +476,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -487,7 +487,7 @@
   "linz:slug": "auckland_waikato_sn348_1944_0.375m",
   "gsd": 0.375,
   "created": "2025-06-11T05:10:02Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:geographic_description": "Auckland / Waikato",
   "linz:historic_survey_number": "SN348",
   "extent": {

--- a/stac/auckland/auckland_waikato_sn9888_2000_0.375m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_waikato_sn9888_2000_0.375m/rgb/2193/collection.json
@@ -740,7 +740,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -751,7 +751,7 @@
   "linz:slug": "auckland_waikato_sn9888_2000_0.375m",
   "gsd": 0.375,
   "created": "2025-06-11T05:09:21Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:36Z",
   "linz:geographic_description": "Auckland / Waikato",
   "linz:historic_survey_number": "SN9888",
   "extent": {

--- a/stac/bay-of-plenty/bay-of-plenty_gisborne_sn5240_1978_0.64m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_gisborne_sn5240_1978_0.64m/rgb/2193/collection.json
@@ -578,7 +578,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -589,7 +589,7 @@
   "linz:slug": "bay-of-plenty_gisborne_sn5240_1978_0.64m",
   "gsd": 0.64,
   "created": "2025-12-01T01:34:48Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:38Z",
   "linz:geographic_description": "Bay of Plenty / Gisborne",
   "linz:historic_survey_number": "SN5240",
   "extent": {

--- a/stac/bay-of-plenty/bay-of-plenty_sn1247_1959_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1247_1959_0.125m/rgb/2193/collection.json
@@ -104,7 +104,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -115,7 +115,7 @@
   "linz:slug": "bay-of-plenty_sn1247_1959_0.125m",
   "gsd": 0.125,
   "created": "2025-12-01T00:43:03Z",
-  "updated": "2025-12-01T00:43:03Z",
+  "updated": "2026-05-18T00:21:38Z",
   "linz:historic_survey_number": "SN1247",
   "extent": {
     "spatial": { "bbox": [[176.2315594, -38.2726961, 176.3453814, -38.1099689]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1422_1962_0.25m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1422_1962_0.25m/rgb/2193/collection.json
@@ -278,7 +278,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -289,7 +289,7 @@
   "linz:slug": "bay-of-plenty_sn1422_1962_0.25m",
   "gsd": 0.25,
   "created": "2025-12-01T00:43:12Z",
-  "updated": "2025-12-01T00:43:12Z",
+  "updated": "2026-05-18T00:21:38Z",
   "linz:historic_survey_number": "SN1422",
   "extent": {
     "spatial": { "bbox": [[176.3194778, -38.7869272, 176.7710404, -38.2586951]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1607_1964_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1607_1964_0.1m/rgb/2193/collection.json
@@ -158,7 +158,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -169,7 +169,7 @@
   "linz:slug": "bay-of-plenty_sn1607_1964_0.1m",
   "gsd": 0.1,
   "created": "2025-12-01T00:43:31Z",
-  "updated": "2025-12-01T00:43:31Z",
+  "updated": "2026-05-18T00:21:38Z",
   "linz:historic_survey_number": "SN1607",
   "extent": {
     "spatial": { "bbox": [[177.2425876, -38.3662212, 177.4768312, -38.0457427]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1740_1965_0.125m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1740_1965_0.125m/rgb/2193/collection.json
@@ -242,7 +242,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -253,7 +253,7 @@
   "linz:slug": "bay-of-plenty_sn1740_1965_0.125m",
   "gsd": 0.125,
   "created": "2025-12-01T00:44:03Z",
-  "updated": "2025-12-01T00:44:03Z",
+  "updated": "2026-05-18T00:21:38Z",
   "linz:historic_survey_number": "SN1740",
   "extent": {
     "spatial": { "bbox": [[176.1523102, -38.3343423, 176.4822579, -38.110737]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1760_1965_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1760_1965_0.1m/rgb/2193/collection.json
@@ -158,7 +158,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -169,7 +169,7 @@
   "linz:slug": "bay-of-plenty_sn1760_1965_0.1m",
   "gsd": 0.1,
   "created": "2025-12-01T00:53:23Z",
-  "updated": "2025-12-01T00:53:23Z",
+  "updated": "2026-05-18T00:21:38Z",
   "linz:historic_survey_number": "SN1760",
   "extent": {
     "spatial": { "bbox": [[177.2623649, -38.0143813, 177.6669085, -37.8371199]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1840_1966-1970_0.25m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1840_1966-1970_0.25m/rgb/2193/collection.json
@@ -86,7 +86,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -97,7 +97,7 @@
   "linz:slug": "bay-of-plenty_sn1840_1966-1970_0.25m",
   "gsd": 0.25,
   "created": "2025-12-01T00:53:31Z",
-  "updated": "2025-12-01T00:53:31Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN1840",
   "extent": {
     "spatial": { "bbox": [[176.6546, -38.5211801, 176.9907657, -38.3809342]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1883_1966_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1883_1966_0.1m/rgb/2193/collection.json
@@ -4124,7 +4124,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -4135,7 +4135,7 @@
   "linz:slug": "bay-of-plenty_sn1883_1966_0.1m",
   "gsd": 0.1,
   "created": "2026-02-03T01:35:07Z",
-  "updated": "2026-02-03T01:35:07Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN1883",
   "extent": {
     "spatial": { "bbox": [[176.0312328, -38.3509241, 176.9730577, -37.9597905]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1896_1966_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1896_1966_0.1m/rgb/2193/collection.json
@@ -122,7 +122,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -133,7 +133,7 @@
   "linz:slug": "bay-of-plenty_sn1896_1966_0.1m",
   "gsd": 0.1,
   "created": "2025-12-01T00:53:43Z",
-  "updated": "2025-12-01T00:53:43Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN1896",
   "extent": {
     "spatial": { "bbox": [[175.9450567, -37.8926367, 176.1873547, -37.6918494]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn1985_1967_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn1985_1967_0.1m/rgb/2193/collection.json
@@ -128,7 +128,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -139,7 +139,7 @@
   "linz:slug": "bay-of-plenty_sn1985_1967_0.1m",
   "gsd": 0.1,
   "created": "2025-12-01T00:53:52Z",
-  "updated": "2025-12-01T00:53:52Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN1985",
   "extent": {
     "spatial": { "bbox": [[176.3077447, -38.1099689, 176.4366503, -37.7821522]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn2461_1972_0.04m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn2461_1972_0.04m/rgb/2193/collection.json
@@ -338,7 +338,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -349,7 +349,7 @@
   "linz:slug": "bay-of-plenty_sn2461_1972_0.04m",
   "gsd": 0.04,
   "created": "2025-12-01T01:16:28Z",
-  "updated": "2025-12-01T01:16:28Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN2461",
   "extent": {
     "spatial": { "bbox": [[176.6830745, -38.1048529, 176.7421645, -38.0453622]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn2463_1972_0.04m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn2463_1972_0.04m/rgb/2193/collection.json
@@ -404,7 +404,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -415,7 +415,7 @@
   "linz:slug": "bay-of-plenty_sn2463_1972_0.04m",
   "gsd": 0.04,
   "created": "2025-12-01T01:16:38Z",
-  "updated": "2025-12-01T01:16:38Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN2463",
   "extent": {
     "spatial": { "bbox": [[176.2315594, -38.177042, 176.2816521, -38.1182804]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn5005_1976_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn5005_1976_0.15m/rgb/2193/collection.json
@@ -176,7 +176,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -187,7 +187,7 @@
   "linz:slug": "bay-of-plenty_sn5005_1976_0.15m",
   "gsd": 0.15,
   "created": "2025-12-01T01:27:21Z",
-  "updated": "2025-12-01T01:27:21Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN5005",
   "extent": {
     "spatial": { "bbox": [[176.1712581, -38.2101873, 176.3424146, -38.014318]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn5299_1978_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn5299_1978_0.15m/rgb/2193/collection.json
@@ -182,7 +182,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -193,7 +193,7 @@
   "linz:slug": "bay-of-plenty_sn5299_1978_0.15m",
   "gsd": 0.15,
   "created": "2025-12-01T01:34:59Z",
-  "updated": "2025-12-01T01:34:59Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN5299",
   "extent": {
     "spatial": { "bbox": [[176.0989869, -37.7912258, 176.2431761, -37.5946546]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn5420_1979_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn5420_1979_0.15m/rgb/2193/collection.json
@@ -110,7 +110,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -121,7 +121,7 @@
   "linz:slug": "bay-of-plenty_sn5420_1979_0.15m",
   "gsd": 0.15,
   "created": "2025-12-01T01:35:23Z",
-  "updated": "2025-12-01T01:35:23Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN5420",
   "extent": {
     "spatial": { "bbox": [[176.2675354, -37.8515907, 176.3821884, -37.7189446]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn588_1951_0.16m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn588_1951_0.16m/rgb/2193/collection.json
@@ -86,7 +86,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -97,7 +97,7 @@
   "linz:slug": "bay-of-plenty_sn588_1951_0.16m",
   "gsd": 0.16,
   "created": "2025-12-01T01:38:14Z",
-  "updated": "2025-12-01T01:38:14Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN588",
   "extent": {
     "spatial": { "bbox": [[176.2027957, -38.2101873, 176.3165304, -38.1099689]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn596_1952_0.5m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn596_1952_0.5m/rgb/2193/collection.json
@@ -476,7 +476,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -487,7 +487,7 @@
   "linz:slug": "bay-of-plenty_sn596_1952_0.5m",
   "gsd": 0.5,
   "created": "2025-12-01T01:45:59Z",
-  "updated": "2025-12-01T01:45:59Z",
+  "updated": "2026-05-18T00:21:39Z",
   "linz:historic_survey_number": "SN596",
   "extent": {
     "spatial": { "bbox": [[176.3077447, -38.3933692, 177.0859859, -37.9240672]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn812_1952-1953_0.32m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn812_1952-1953_0.32m/rgb/2193/collection.json
@@ -206,7 +206,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -217,7 +217,7 @@
   "linz:slug": "bay-of-plenty_sn812_1952-1953_0.32m",
   "gsd": 0.32,
   "created": "2025-12-01T01:46:05Z",
-  "updated": "2025-12-01T01:46:05Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN812",
   "extent": {
     "spatial": { "bbox": [[176.2272016, -38.856484, 176.6677392, -38.5211801]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8154_1982-1983_0.375m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8154_1982-1983_0.375m/rgb/2193/collection.json
@@ -212,7 +212,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -223,7 +223,7 @@
   "linz:slug": "bay-of-plenty_sn8154_1982-1983_0.375m",
   "gsd": 0.375,
   "created": "2025-12-01T01:46:12Z",
-  "updated": "2025-12-01T01:46:12Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN8154",
   "extent": {
     "spatial": { "bbox": [[176.8022243, -38.2569268, 177.41419, -38.0417002]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8156_1982_0.08m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8156_1982_0.08m/rgb/2193/collection.json
@@ -2828,7 +2828,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -2839,7 +2839,7 @@
   "linz:slug": "bay-of-plenty_sn8156_1982_0.08m",
   "gsd": 0.08,
   "created": "2025-12-01T01:46:27Z",
-  "updated": "2025-12-01T01:46:27Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN8156",
   "extent": {
     "spatial": { "bbox": [[176.2111966, -38.0915567, 176.785632, -37.6710788]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn845_1954_0.05m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn845_1954_0.05m/rgb/2193/collection.json
@@ -122,7 +122,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -133,7 +133,7 @@
   "linz:slug": "bay-of-plenty_sn845_1954_0.05m",
   "gsd": 0.05,
   "created": "2025-12-01T02:00:37Z",
-  "updated": "2025-12-01T02:00:37Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN845",
   "extent": {
     "spatial": { "bbox": [[177.2631152, -38.0271255, 177.2864307, -37.9941736]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn845_1954_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn845_1954_0.2m/rgb/2193/collection.json
@@ -74,7 +74,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -85,7 +85,7 @@
   "linz:slug": "bay-of-plenty_sn845_1954_0.2m",
   "gsd": 0.2,
   "created": "2025-12-01T02:00:28Z",
-  "updated": "2025-12-01T02:00:28Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN845",
   "extent": {
     "spatial": { "bbox": [[177.235111, -38.1124399, 177.3244885, -37.9810323]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8736_1987_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8736_1987_0.2m/rgb/2193/collection.json
@@ -134,7 +134,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -145,7 +145,7 @@
   "linz:slug": "bay-of-plenty_sn8736_1987_0.2m",
   "gsd": 0.2,
   "created": "2025-12-01T02:03:06Z",
-  "updated": "2025-12-01T02:03:06Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN8736",
   "extent": {
     "spatial": { "bbox": [[177.235111, -38.1124399, 177.4063772, -37.9790284]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8736_1987_0.5m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8736_1987_0.5m/rgb/2193/collection.json
@@ -50,7 +50,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -61,7 +61,7 @@
   "linz:slug": "bay-of-plenty_sn8736_1987_0.5m",
   "gsd": 0.5,
   "created": "2025-12-01T02:03:28Z",
-  "updated": "2025-12-01T02:03:28Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN8736",
   "extent": {
     "spatial": { "bbox": [[177.235111, -38.1124399, 177.4063772, -37.9769992]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8763_1987_0.6m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8763_1987_0.6m/rgb/2193/collection.json
@@ -194,7 +194,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -205,7 +205,7 @@
   "linz:slug": "bay-of-plenty_sn8763_1987_0.6m",
   "gsd": 0.6,
   "created": "2025-12-04T02:57:12Z",
-  "updated": "2025-12-04T02:57:12Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN8763",
   "extent": {
     "spatial": { "bbox": [[176.6256461, -38.1326369, 177.0751492, -37.8054204]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8925_19880220_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8925_19880220_0.15m/rgb/2193/collection.json
@@ -44,7 +44,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -55,7 +55,7 @@
   "linz:slug": "bay-of-plenty_sn8925_19880220_0.15m",
   "gsd": 0.15,
   "created": "2025-12-04T03:51:47Z",
-  "updated": "2025-12-04T03:51:47Z",
+  "updated": "2026-05-18T00:21:40Z",
   "linz:historic_survey_number": "SN8925",
   "extent": {
     "spatial": { "bbox": [[176.7782621, -38.1921802, 176.863648, -38.1256473]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8925_19880226_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8925_19880226_0.1m/rgb/2193/collection.json
@@ -44,7 +44,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -55,7 +55,7 @@
   "linz:slug": "bay-of-plenty_sn8925_19880226_0.1m",
   "gsd": 0.1,
   "created": "2025-12-05T00:41:41Z",
-  "updated": "2025-12-05T00:41:41Z",
+  "updated": "2026-05-18T00:21:41Z",
   "linz:historic_survey_number": "SN8925",
   "extent": {
     "spatial": { "bbox": [[176.7765922, -38.1921802, 176.863648, -38.0941701]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8925_19880304_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8925_19880304_0.15m/rgb/2193/collection.json
@@ -56,7 +56,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -67,7 +67,7 @@
   "linz:slug": "bay-of-plenty_sn8925_19880304_0.15m",
   "gsd": 0.15,
   "created": "2025-12-05T00:43:02Z",
-  "updated": "2025-12-05T00:43:02Z",
+  "updated": "2026-05-18T00:21:41Z",
   "linz:historic_survey_number": "SN8925",
   "extent": {
     "spatial": { "bbox": [[176.7765922, -38.1921802, 176.863648, -38.0941701]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8925_19880320_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8925_19880320_0.15m/rgb/2193/collection.json
@@ -68,7 +68,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -79,7 +79,7 @@
   "linz:slug": "bay-of-plenty_sn8925_19880320_0.15m",
   "gsd": 0.15,
   "created": "2025-12-05T00:44:33Z",
-  "updated": "2025-12-05T00:44:33Z",
+  "updated": "2026-05-18T00:21:41Z",
   "linz:historic_survey_number": "SN8925",
   "extent": {
     "spatial": { "bbox": [[176.7765922, -38.2245536, 176.865362, -38.0941701]] },

--- a/stac/bay-of-plenty/bay-of-plenty_sn8925_19880403_0.15m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_sn8925_19880403_0.15m/rgb/2193/collection.json
@@ -68,7 +68,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -79,7 +79,7 @@
   "linz:slug": "bay-of-plenty_sn8925_19880403_0.15m",
   "gsd": 0.15,
   "created": "2025-12-05T00:45:08Z",
-  "updated": "2025-12-05T00:45:08Z",
+  "updated": "2026-05-18T00:21:41Z",
   "linz:historic_survey_number": "SN8925",
   "extent": {
     "spatial": { "bbox": [[176.7765922, -38.2245536, 176.865362, -38.0941701]] },

--- a/stac/bay-of-plenty/bay-of-plenty_waikato_sn827_1953_0.48m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_waikato_sn827_1953_0.48m/rgb/2193/collection.json
@@ -620,7 +620,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -631,7 +631,7 @@
   "linz:slug": "bay-of-plenty_waikato_sn827_1953_0.48m",
   "gsd": 0.48,
   "created": "2025-12-01T02:00:24Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:41Z",
   "linz:geographic_description": "Bay of Plenty / Waikato",
   "linz:historic_survey_number": "SN827",
   "extent": {

--- a/stac/gisborne/gisborne_bay-of-plenty_sn3298_1970-1972_0.375m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_bay-of-plenty_sn3298_1970-1972_0.375m/rgb/2193/collection.json
@@ -1352,7 +1352,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Bay of Plenty Regional Council", "roles": ["licensor"] }
   ],
@@ -1363,7 +1363,7 @@
   "linz:slug": "gisborne_bay-of-plenty_sn3298_1970-1972_0.375m",
   "gsd": 0.375,
   "created": "2025-12-01T01:19:54Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:48Z",
   "linz:geographic_description": "Gisborne / Bay of Plenty",
   "linz:historic_survey_number": "SN3298",
   "extent": {

--- a/stac/hawkes-bay/hawkes-bay_sn9585_1996_0.8m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_sn9585_1996_0.8m/rgb/2193/collection.json
@@ -836,7 +836,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Ministry for Primary Industries", "roles": ["licensor"] }
   ],
@@ -849,7 +849,7 @@
     "temporal": { "interval": [["1996-12-11T11:00:00Z", "1996-12-16T11:00:00Z"]] }
   },
   "created": "2023-09-11T02:25:24Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:21:49Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "linz:lifecycle": "completed",
   "linz:geospatial_category": "scanned-aerial-photos",

--- a/stac/waikato/waikato_auckland_sn3607_1972-1973_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_auckland_sn3607_1972-1973_0.3m/rgb/2193/collection.json
@@ -350,7 +350,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -361,7 +361,7 @@
   "linz:slug": "waikato_auckland_sn3607_1972-1973_0.3m",
   "gsd": 0.3,
   "created": "2025-06-11T04:53:21Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:22:03Z",
   "linz:geographic_description": "Waikato / Auckland",
   "linz:historic_survey_number": "SN3607",
   "extent": {

--- a/stac/waikato/waikato_auckland_sn9997c_2001_0.6m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_auckland_sn9997c_2001_0.6m/rgb/2193/collection.json
@@ -3212,7 +3212,7 @@
     }
   ],
   "providers": [
-    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor"] },
+    { "name": "Toitū Te Whenua Land Information New Zealand", "roles": ["host", "processor", "licensor"] },
     { "name": "SKYVUW", "roles": ["producer"] },
     { "name": "Auckland Council", "roles": ["licensor"] }
   ],
@@ -3223,7 +3223,7 @@
   "linz:slug": "waikato_auckland_sn9997c_2001_0.6m",
   "gsd": 0.6,
   "created": "2025-06-11T04:57:05Z",
-  "updated": "2026-05-04T00:00:00Z",
+  "updated": "2026-05-18T00:22:03Z",
   "linz:geographic_description": "Waikato / Auckland",
   "linz:historic_survey_number": "SN9997C",
   "extent": {


### PR DESCRIPTION
Orthorectified imagery sourced from Crown archive of scanned aerial imagery.
Add Toitū Te Whenua Land Information New Zealand as joint licensor.