### PR TITLE
chore: backfill gsd field into collection.json files

### DIFF
--- a/stac/auckland/auckland-central_2023_0.06m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-central_2023_0.06m/rgb/2193/collection.json
@@ -803,5 +803,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.06,
   "created": "2024-05-05T22:31:17Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/auckland/auckland-central_2023_0.06m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-central_2023_0.06m/rgb/2193/collection.json
@@ -801,6 +801,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.06,
   "created": "2024-05-05T22:31:17Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
@@ -27192,5 +27192,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.05,
   "created": "2024-01-04T01:23:16Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2022-2023_0.05m/rgb/2193/collection.json
@@ -27190,6 +27190,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05,
   "created": "2024-01-04T01:23:16Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
@@ -18252,5 +18252,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.05,
   "created": "2024-06-16T23:39:36Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
+++ b/stac/auckland/auckland-coast_2023_0.05m/rgb/2193/collection.json
@@ -18250,6 +18250,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05,
   "created": "2024-06-16T23:39:36Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/auckland/auckland_2024_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2024_0.075m/rgb/2193/collection.json
@@ -106458,7 +106458,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "auckland_2024_0.075m",
   "created": "2025-02-24T21:42:53Z",
-  "updated": "2025-07-16T03:32:07Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[174.1568679, -37.2950242, 175.5557893, -36.0230606]] },
     "temporal": { "interval": [["2024-01-31T11:00:00Z", "2025-03-05T11:00:00Z"]] }

--- a/stac/auckland/auckland_2024_0.075m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2024_0.075m/rgb/2193/collection.json
@@ -106474,5 +106474,6 @@
       "file:size": 40743
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/auckland/auckland_2024_0.25m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2024_0.25m/rgb/2193/collection.json
@@ -1401,5 +1401,6 @@
       "file:size": 1962
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/auckland/auckland_2024_0.25m/rgb/2193/collection.json
+++ b/stac/auckland/auckland_2024_0.25m/rgb/2193/collection.json
@@ -1385,7 +1385,7 @@
   "linz:region": "auckland",
   "linz:security_classification": "unclassified",
   "created": "2024-06-10T00:34:22Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "auckland_2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[174.233687, -37.1732183, 174.8088539, -36.4916071]] },

--- a/stac/bay-of-plenty/bay-of-plenty-east_2024-2025_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty-east_2024-2025_0.2m/rgb/2193/collection.json
@@ -35682,7 +35682,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty-east_2024-2025_0.2m",
   "created": "2025-04-03T21:44:06Z",
-  "updated": "2025-04-03T21:44:06Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Bay of Plenty East",
   "extent": {
     "spatial": { "bbox": [[176.4717983, -38.8708396, 178.1159018, -37.5044752]] },

--- a/stac/bay-of-plenty/bay-of-plenty-east_2024-2025_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty-east_2024-2025_0.2m/rgb/2193/collection.json
@@ -35699,5 +35699,6 @@
       "file:size": 10579
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2010-2012_0.4m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2010-2012_0.4m/rgb/2193/collection.json
@@ -8525,5 +8525,6 @@
       "file:size": 7763
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.4
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2010-2012_0.4m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2010-2012_0.4m/rgb/2193/collection.json
@@ -8508,7 +8508,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty_2010-2012_0.4m",
   "created": "2025-08-05T21:39:20Z",
-  "updated": "2025-08-05T21:39:20Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Bay of Plenty",
   "extent": {
     "spatial": { "bbox": [[175.7954587, -39.0168413, 178.1994095, -37.2353163]] },

--- a/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
@@ -2272,5 +2272,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.2,
   "created": "2024-04-17T23:58:59Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2023-2024_0.2m/rgb/2193/collection.json
@@ -2270,6 +2270,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2,
   "created": "2024-04-17T23:58:59Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/bay-of-plenty/bay-of-plenty_2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2024_0.2m/rgb/2193/collection.json
@@ -32052,7 +32052,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "bay-of-plenty_2024_0.2m",
   "created": "2024-09-11T03:33:01Z",
-  "updated": "2025-03-21T01:01:33Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Bay of Plenty West",
   "extent": {
     "spatial": { "bbox": [[175.784855, -39.0226788, 176.7342564, -37.3345833]] },

--- a/stac/bay-of-plenty/bay-of-plenty_2024_0.2m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/bay-of-plenty_2024_0.2m/rgb/2193/collection.json
@@ -32069,5 +32069,6 @@
       "file:size": 9758
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2
 }

--- a/stac/bay-of-plenty/tauranga_2025_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2025_0.1m/rgb/2193/collection.json
@@ -5436,7 +5436,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "tauranga_2025_0.1m",
   "created": "2025-05-22T23:03:51Z",
-  "updated": "2025-05-22T23:03:51Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Tauranga",
   "extent": {
     "spatial": { "bbox": [[176.0145482, -37.8388559, 176.4273057, -37.6205734]] },

--- a/stac/bay-of-plenty/tauranga_2025_0.1m/rgb/2193/collection.json
+++ b/stac/bay-of-plenty/tauranga_2025_0.1m/rgb/2193/collection.json
@@ -5453,5 +5453,6 @@
       "file:size": 3936
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/canterbury/ashburton_2023-2024_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2023-2024_0.075m/rgb/2193/collection.json
@@ -18468,7 +18468,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "created": "2024-08-05T21:57:31Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Ashburton",
   "linz:slug": "ashburton_2023-2024_0.075m",
   "extent": {

--- a/stac/canterbury/ashburton_2023-2024_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/ashburton_2023-2024_0.075m/rgb/2193/collection.json
@@ -18485,5 +18485,6 @@
       "file:size": 12517
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/canterbury/banks-peninsula_2025_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2025_0.075m/rgb/2193/collection.json
@@ -12528,7 +12528,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "banks-peninsula_2025_0.075m",
   "created": "2025-07-17T02:39:08Z",
-  "updated": "2025-08-27T00:13:28Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Banks Peninsula",
   "extent": {
     "spatial": { "bbox": [[172.6745949, -43.8448194, 173.1043475, -43.6275324]] },

--- a/stac/canterbury/banks-peninsula_2025_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/banks-peninsula_2025_0.075m/rgb/2193/collection.json
@@ -12545,5 +12545,6 @@
       "file:size": 4054
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/canterbury/canterbury_2024_0.2m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2024_0.2m/rgb/2193/collection.json
@@ -10552,5 +10552,6 @@
       "file:size": 6404
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2
 }

--- a/stac/canterbury/canterbury_2024_0.2m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2024_0.2m/rgb/2193/collection.json
@@ -10536,7 +10536,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "canterbury_2024_0.2m",
   "created": "2024-11-29T02:38:44Z",
-  "updated": "2024-12-10T01:32:57Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[170.8013469, -44.5310251, 172.7333572, -42.7240017]] },
     "temporal": { "interval": [["2024-01-10T11:00:00Z", "2024-04-19T12:00:00Z"]] }

--- a/stac/canterbury/canterbury_2025_0.25m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2025_0.25m/rgb/2193/collection.json
@@ -12670,5 +12670,6 @@
       "file:size": 16013
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/canterbury/canterbury_2025_0.25m/rgb/2193/collection.json
+++ b/stac/canterbury/canterbury_2025_0.25m/rgb/2193/collection.json
@@ -12654,7 +12654,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "canterbury_2025_0.25m",
   "created": "2025-07-23T23:17:31Z",
-  "updated": "2025-08-07T23:25:34Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[171.7968923, -43.9939421, 174.1303787, -41.8176775]] },
     "temporal": { "interval": [["2025-02-04T11:00:00Z", "2025-04-08T12:00:00Z"]] }

--- a/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
@@ -41987,5 +41987,6 @@
   },
   "created": "2023-09-09T00:00:00Z",
   "updated": "2026-05-05T00:00:00Z",
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2015-2016_0.075m/rgb/2193/collection.json
@@ -41986,7 +41986,7 @@
     "temporal": { "interval": [["2016-01-21T11:00:00Z", "2016-02-19T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-05-05T00:00:00Z",
+  "updated": "2026-06-25T02:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.075
 }

--- a/stac/canterbury/christchurch_2025_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2025_0.05m/rgb/2193/collection.json
@@ -1164,7 +1164,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2025_0.05m",
   "created": "2025-09-19T03:39:45Z",
-  "updated": "2025-09-19T03:39:45Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Christchurch",
   "extent": {
     "spatial": { "bbox": [[172.6048675, -43.546128, 172.6614953, -43.5135323]] },

--- a/stac/canterbury/christchurch_2025_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2025_0.05m/rgb/2193/collection.json
@@ -1181,5 +1181,6 @@
       "file:size": 329
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05
 }

--- a/stac/canterbury/christchurch_2025_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2025_0.075m/rgb/2193/collection.json
@@ -49116,7 +49116,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "christchurch_2025_0.075m",
   "created": "2025-09-24T02:13:25Z",
-  "updated": "2025-09-24T02:13:25Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Christchurch",
   "extent": {
     "spatial": { "bbox": [[172.3769515, -43.6822319, 172.8424045, -43.3712458]] },

--- a/stac/canterbury/christchurch_2025_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/christchurch_2025_0.075m/rgb/2193/collection.json
@@ -49133,5 +49133,6 @@
       "file:size": 6310
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
@@ -654,7 +654,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "created": "2024-08-06T23:40:05Z",
-  "updated": "2026-05-06T03:00:00Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Kaikōura",
   "linz:slug": "kaikoura_2023_0.05m",
   "extent": {

--- a/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
+++ b/stac/canterbury/kaikoura_2023_0.05m/rgb/2193/collection.json
@@ -671,5 +671,6 @@
       "file:size": 2359
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05
 }

--- a/stac/canterbury/port-hills-false-colour_2024_10m/rgb/2193/collection.json
+++ b/stac/canterbury/port-hills-false-colour_2024_10m/rgb/2193/collection.json
@@ -44,6 +44,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10,
   "created": "2024-02-19T03:29:29Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/canterbury/port-hills-false-colour_2024_10m/rgb/2193/collection.json
+++ b/stac/canterbury/port-hills-false-colour_2024_10m/rgb/2193/collection.json
@@ -46,5 +46,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 10,
   "created": "2024-02-19T03:29:29Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/canterbury/port-hills_2024_10m/rgb/2193/collection.json
+++ b/stac/canterbury/port-hills_2024_10m/rgb/2193/collection.json
@@ -44,6 +44,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10,
   "created": "2024-02-19T03:39:52Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/canterbury/port-hills_2024_10m/rgb/2193/collection.json
+++ b/stac/canterbury/port-hills_2024_10m/rgb/2193/collection.json
@@ -46,5 +46,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 10,
   "created": "2024-02-19T03:39:52Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/canterbury/waimakariri_2024_0.25m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2024_0.25m/rgb/2193/collection.json
@@ -1763,7 +1763,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "created": "2024-07-01T23:37:43Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Waimakariri",
   "linz:slug": "waimakariri_2024_0.25m",
   "extent": {

--- a/stac/canterbury/waimakariri_2024_0.25m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2024_0.25m/rgb/2193/collection.json
@@ -1780,5 +1780,6 @@
       "file:size": 3510
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/canterbury/waimakariri_2025_0.04m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2025_0.04m/rgb/2193/collection.json
@@ -23357,5 +23357,6 @@
       "file:size": 3713
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.04
 }

--- a/stac/canterbury/waimakariri_2025_0.04m/rgb/2193/collection.json
+++ b/stac/canterbury/waimakariri_2025_0.04m/rgb/2193/collection.json
@@ -23340,7 +23340,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "waimakariri_2025_0.04m",
   "created": "2025-06-30T22:08:08Z",
-  "updated": "2025-06-30T22:08:08Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Waimakariri",
   "extent": {
     "spatial": { "bbox": [[172.1417287, -43.4101301, 172.7427244, -43.2572206]] },

--- a/stac/canterbury/waimate_2025_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2025_0.075m/rgb/2193/collection.json
@@ -13848,7 +13848,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "waimate_2025_0.075m",
   "created": "2025-07-17T03:05:30Z",
-  "updated": "2025-09-03T22:39:29Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Waimate",
   "extent": {
     "spatial": { "bbox": [[170.4684723, -44.9508083, 171.2246045, -44.4979643]] },

--- a/stac/canterbury/waimate_2025_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waimate_2025_0.075m/rgb/2193/collection.json
@@ -13865,5 +13865,6 @@
       "file:size": 5990
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/canterbury/waitaki_2023-2024_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waitaki_2023-2024_0.075m/rgb/2193/collection.json
@@ -9203,5 +9203,6 @@
       "file:size": 7223
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/canterbury/waitaki_2023-2024_0.075m/rgb/2193/collection.json
+++ b/stac/canterbury/waitaki_2023-2024_0.075m/rgb/2193/collection.json
@@ -9186,7 +9186,7 @@
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
   "created": "2024-08-06T21:55:52Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Waitaki",
   "linz:slug": "waitaki_2023-2024_0.075m",
   "extent": {

--- a/stac/gisborne/gisborne_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023-2024_0.2m/rgb/2193/collection.json
@@ -6850,5 +6850,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.2,
   "created": "2024-05-24T00:16:17Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/gisborne/gisborne_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023-2024_0.2m/rgb/2193/collection.json
@@ -6848,6 +6848,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2,
   "created": "2024-05-24T00:16:17Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/gisborne/gisborne_2023_0.075m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023_0.075m/rgb/2193/collection.json
@@ -11864,6 +11864,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075,
   "created": "2024-02-27T02:44:29Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/gisborne/gisborne_2023_0.075m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2023_0.075m/rgb/2193/collection.json
@@ -11866,5 +11866,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.075,
   "created": "2024-02-27T02:44:29Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/gisborne/gisborne_2024-2025_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2024-2025_0.1m/rgb/2193/collection.json
@@ -108894,7 +108894,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "gisborne_2024-2025_0.1m",
   "created": "2025-02-23T23:01:04Z",
-  "updated": "2025-02-23T23:01:04Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[177.4034138, -38.9760729, 178.466825, -37.7304396]] },
     "temporal": { "interval": [["2024-09-28T12:00:00Z", "2025-01-07T11:00:00Z"]] }

--- a/stac/gisborne/gisborne_2024-2025_0.1m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2024-2025_0.1m/rgb/2193/collection.json
@@ -108910,5 +108910,6 @@
       "file:size": 19098
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/gisborne/gisborne_2024-2025_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2024-2025_0.2m/rgb/2193/collection.json
@@ -42310,5 +42310,6 @@
       "file:size": 14589
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2
 }

--- a/stac/gisborne/gisborne_2024-2025_0.2m/rgb/2193/collection.json
+++ b/stac/gisborne/gisborne_2024-2025_0.2m/rgb/2193/collection.json
@@ -42294,7 +42294,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "gisborne_2024-2025_0.2m",
   "created": "2025-02-20T04:21:41Z",
-  "updated": "2025-02-20T04:21:41Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[177.1156421, -38.6618607, 178.5838495, -37.5284958]] },
     "temporal": { "interval": [["2024-09-28T12:00:00Z", "2025-01-07T11:00:00Z"]] }

--- a/stac/hawkes-bay/hawkes-bay-coast_2024_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay-coast_2024_0.1m/rgb/2193/collection.json
@@ -10956,7 +10956,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "hawkes-bay-coast_2024_0.1m",
   "created": "2025-01-03T01:30:46Z",
-  "updated": "2025-01-03T01:30:46Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Hawke's Bay Coast",
   "extent": {
     "spatial": { "bbox": [[176.615275, -40.4357043, 178.012678, -38.9684491]] },

--- a/stac/hawkes-bay/hawkes-bay-coast_2024_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay-coast_2024_0.1m/rgb/2193/collection.json
@@ -10973,5 +10973,6 @@
       "file:size": 48603
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/hawkes-bay/hawkes-bay_2010-2011_0.4m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2010-2011_0.4m/rgb/2193/collection.json
@@ -10559,5 +10559,6 @@
       "file:size": 6379
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.4
 }

--- a/stac/hawkes-bay/hawkes-bay_2010-2011_0.4m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2010-2011_0.4m/rgb/2193/collection.json
@@ -10542,7 +10542,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "hawkes-bay_2010-2011_0.4m",
   "created": "2025-08-05T22:59:53Z",
-  "updated": "2025-08-05T22:59:53Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Hawke's Bay",
   "extent": {
     "spatial": { "bbox": [[176.0800727, -40.4415595, 178.0237405, -38.5683905]] },

--- a/stac/hawkes-bay/hawkes-bay_2023-2024_0.125m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023-2024_0.125m/rgb/2193/collection.json
@@ -11027,7 +11027,7 @@
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "created": "2024-02-20T01:47:54Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "hawkes-bay_2023-2024_0.125m",
   "extent": {
     "spatial": { "bbox": [[176.0358006, -40.4415595, 178.0237405, -38.5683905]] },

--- a/stac/hawkes-bay/hawkes-bay_2023-2024_0.125m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023-2024_0.125m/rgb/2193/collection.json
@@ -11043,5 +11043,6 @@
       "file:size": 32217
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.125
 }

--- a/stac/hawkes-bay/hawkes-bay_2023-2024_0.25m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023-2024_0.25m/rgb/2193/collection.json
@@ -11638,5 +11638,6 @@
       "file:size": 7331
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/hawkes-bay/hawkes-bay_2023-2024_0.25m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2023-2024_0.25m/rgb/2193/collection.json
@@ -11621,7 +11621,7 @@
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "created": "2024-02-08T08:54:38Z",
-  "updated": "2025-04-28T04:46:01Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "hawkes-bay_2023-2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[176.0343987, -40.4678951, 178.0260432, -38.5360339]] },

--- a/stac/hawkes-bay/hawkes-bay_2024-2025_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2024-2025_0.1m/rgb/2193/collection.json
@@ -13140,5 +13140,6 @@
       "file:size": 13148
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/hawkes-bay/hawkes-bay_2024-2025_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/hawkes-bay_2024-2025_0.1m/rgb/2193/collection.json
@@ -13124,7 +13124,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "hawkes-bay_2024-2025_0.1m",
   "created": "2025-05-02T00:17:59Z",
-  "updated": "2025-05-02T00:17:59Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[176.3122772, -40.3198799, 177.0370161, -39.3171429]] },
     "temporal": { "interval": [["2024-12-12T11:00:00Z", "2025-02-24T11:00:00Z"]] }

--- a/stac/hawkes-bay/napier_2024-2025_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2024-2025_0.05m/rgb/2193/collection.json
@@ -3204,7 +3204,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "napier_2024-2025_0.05m",
   "created": "2025-05-02T00:05:34Z",
-  "updated": "2025-05-02T00:05:34Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Napier",
   "extent": {
     "spatial": { "bbox": [[176.8275888, -39.5632851, 176.927647, -39.3990781]] },

--- a/stac/hawkes-bay/napier_2024-2025_0.05m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/napier_2024-2025_0.05m/rgb/2193/collection.json
@@ -3221,5 +3221,6 @@
       "file:size": 3612
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05
 }

--- a/stac/hawkes-bay/wairoa-flood_2024_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa-flood_2024_0.1m/rgb/2193/collection.json
@@ -185,7 +185,7 @@
   "linz:region": "hawkes-bay",
   "linz:security_classification": "unclassified",
   "created": "2024-07-11T04:40:33Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:event_name": "Wairoa Flood",
   "linz:geographic_description": "Wairoa Flood",
   "linz:slug": "wairoa-flood_2024_0.1m",

--- a/stac/hawkes-bay/wairoa-flood_2024_0.1m/rgb/2193/collection.json
+++ b/stac/hawkes-bay/wairoa-flood_2024_0.1m/rgb/2193/collection.json
@@ -203,5 +203,6 @@
       "file:size": 1762
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2010-2011_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2010-2011_0.4m/rgb/2193/collection.json
@@ -17591,5 +17591,6 @@
       "file:size": 6993
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.4
 }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2010-2011_0.4m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2010-2011_0.4m/rgb/2193/collection.json
@@ -17574,7 +17574,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "manawatu-whanganui_2010-2011_0.4m",
   "created": "2025-08-05T22:56:11Z",
-  "updated": "2025-08-05T22:56:11Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Manawatū-Whanganui",
   "extent": {
     "spatial": { "bbox": [[174.6649364, -40.8034341, 176.681633, -38.4532011]] },

--- a/stac/manawatu-whanganui/manawatu-whanganui_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2023-2024_0.2m/rgb/2193/collection.json
@@ -2428,5 +2428,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.2,
   "created": "2024-06-16T23:29:05Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2023-2024_0.2m/rgb/2193/collection.json
@@ -2426,6 +2426,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2,
   "created": "2024-06-16T23:29:05Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2024_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2024_0.125m/rgb/2193/collection.json
@@ -7868,6 +7868,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.125,
   "created": "2024-05-14T23:00:59Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/manawatu-whanganui/manawatu-whanganui_2024_0.125m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/manawatu-whanganui_2024_0.125m/rgb/2193/collection.json
@@ -7870,5 +7870,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.125,
   "created": "2024-05-14T23:00:59Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/manawatu-whanganui/palmerston-north_2024_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2024_0.1m/rgb/2193/collection.json
@@ -5086,5 +5086,6 @@
       "file:size": 3008
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/manawatu-whanganui/palmerston-north_2024_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/palmerston-north_2024_0.1m/rgb/2193/collection.json
@@ -5069,7 +5069,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "created": "2024-06-20T03:49:10Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Palmerston North",
   "linz:slug": "palmerston-north_2024_0.1m",
   "extent": {

--- a/stac/manawatu-whanganui/tararua_2024_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/tararua_2024_0.1m/rgb/2193/collection.json
@@ -3237,6 +3237,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1,
   "created": "2024-03-28T03:20:23Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/manawatu-whanganui/tararua_2024_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/tararua_2024_0.1m/rgb/2193/collection.json
@@ -3239,5 +3239,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.1,
   "created": "2024-03-28T03:20:23Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/manawatu-whanganui/whanganui-river-catchment_2025_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui-river-catchment_2025_0.1m/rgb/2193/collection.json
@@ -6348,7 +6348,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "whanganui-river-catchment_2025_0.1m",
   "created": "2025-06-27T02:47:06Z",
-  "updated": "2025-08-17T22:54:01Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Whanganui River Catchment",
   "extent": {
     "spatial": { "bbox": [[174.738873, -40.0524505, 175.7160195, -38.4525977]] },

--- a/stac/manawatu-whanganui/whanganui-river-catchment_2025_0.1m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui-river-catchment_2025_0.1m/rgb/2193/collection.json
@@ -6365,5 +6365,6 @@
       "file:size": 21404
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/manawatu-whanganui/whanganui_2022_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2022_0.075m/rgb/2193/collection.json
@@ -5417,5 +5417,6 @@
       "file:size": 1491
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/manawatu-whanganui/whanganui_2022_0.075m/rgb/2193/collection.json
+++ b/stac/manawatu-whanganui/whanganui_2022_0.075m/rgb/2193/collection.json
@@ -5399,7 +5399,7 @@
   "linz:region": "manawatu-whanganui",
   "linz:security_classification": "unclassified",
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Whanganui",
   "linz:slug": "whanganui_2022_0.075m",
   "extent": {

--- a/stac/marlborough/marlborough_2011-2012_0.4m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2011-2012_0.4m/rgb/2193/collection.json
@@ -81893,5 +81893,6 @@
       "file:size": 12668
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.4
 }

--- a/stac/marlborough/marlborough_2011-2012_0.4m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2011-2012_0.4m/rgb/2193/collection.json
@@ -81876,7 +81876,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "marlborough_2011-2012_0.4m",
   "created": "2025-08-06T01:10:14Z",
-  "updated": "2025-08-06T01:10:14Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Marlborough",
   "extent": {
     "spatial": { "bbox": [[172.7973604, -41.9321233, 174.4464073, -40.6629586]] },

--- a/stac/marlborough/marlborough_2017-2018_0.3m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2017-2018_0.3m/rgb/2193/collection.json
@@ -4120,5 +4120,6 @@
       "file:size": 13500
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.3
 }

--- a/stac/marlborough/marlborough_2017-2018_0.3m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2017-2018_0.3m/rgb/2193/collection.json
@@ -4103,7 +4103,7 @@
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "marlborough_2017-2018_0.3m",
   "extent": {
     "spatial": { "bbox": [[173.0287974, -41.6921453, 174.4582684, -40.6499379]] },

--- a/stac/marlborough/marlborough_2023_0.25m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.25m/rgb/2193/collection.json
@@ -21453,5 +21453,6 @@
       "file:size": 8187
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/marlborough/marlborough_2023_0.25m/rgb/2193/collection.json
+++ b/stac/marlborough/marlborough_2023_0.25m/rgb/2193/collection.json
@@ -21437,7 +21437,7 @@
   "linz:region": "marlborough",
   "linz:security_classification": "unclassified",
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "marlborough_2023_0.25m",
   "extent": {
     "spatial": { "bbox": [[173.0057635, -41.6921534, 174.4466921, -40.649988]] },

--- a/stac/nelson/nelson_2022_0.25m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2022_0.25m/rgb/2193/collection.json
@@ -504,7 +504,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "nelson_2022_0.25m",
   "created": "2025-09-02T22:26:18Z",
-  "updated": "2025-09-02T22:26:18Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[173.1719264, -41.4001631, 173.6011333, -41.0420661]] },
     "temporal": { "interval": [["2022-12-28T11:00:00Z", "2022-12-28T11:00:00Z"]] }

--- a/stac/nelson/nelson_2022_0.25m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2022_0.25m/rgb/2193/collection.json
@@ -520,5 +520,6 @@
       "file:size": 1251
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/nelson/nelson_2023_0.075m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2023_0.075m/rgb/2193/collection.json
@@ -6022,5 +6022,6 @@
       "file:size": 5935
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/nelson/nelson_2023_0.075m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2023_0.075m/rgb/2193/collection.json
@@ -6006,7 +6006,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "nelson_2023_0.075m",
   "created": "2025-09-02T22:36:29Z",
-  "updated": "2025-09-02T22:36:29Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[173.1834789, -41.3934951, 173.5661143, -41.1006647]] },
     "temporal": { "interval": [["2023-10-24T11:00:00Z", "2023-11-11T11:00:00Z"]] }

--- a/stac/nelson/nelson_2025_0.1m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2025_0.1m/rgb/2193/collection.json
@@ -8776,5 +8776,6 @@
       "file:size": 160904
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/nelson/nelson_2025_0.1m/rgb/2193/collection.json
+++ b/stac/nelson/nelson_2025_0.1m/rgb/2193/collection.json
@@ -8760,7 +8760,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "nelson_2025_0.1m",
   "created": "2025-08-18T01:51:17Z",
-  "updated": "2025-08-18T01:51:17Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[173.1720115, -41.3935092, 173.6001271, -41.0485517]] },
     "temporal": { "interval": [["2025-05-19T12:00:00Z", "2025-05-22T12:00:00Z"]] }

--- a/stac/new-zealand/nearshore-islands_2010-2021_0.5m/rgb/2193/collection.json
+++ b/stac/new-zealand/nearshore-islands_2010-2021_0.5m/rgb/2193/collection.json
@@ -491,7 +491,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "nearshore-islands_2010-2021_0.5m",
   "created": "2025-08-06T03:00:13Z",
-  "updated": "2025-08-06T03:00:13Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Nearshore Islands",
   "extent": {
     "spatial": { "bbox": [[166.8283863, -46.8541067, 176.5649961, -34.1286928]] },

--- a/stac/new-zealand/nearshore-islands_2010-2021_0.5m/rgb/2193/collection.json
+++ b/stac/new-zealand/nearshore-islands_2010-2021_0.5m/rgb/2193/collection.json
@@ -508,5 +508,6 @@
       "file:size": 5086
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.5
 }

--- a/stac/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
@@ -2740,5 +2740,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 10,
   "created": "2024-03-25T22:19:42Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2020-2021_10m/rgb/2193/collection.json
@@ -2738,6 +2738,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10,
   "created": "2024-03-25T22:19:42Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/new-zealand/new-zealand_2021-2022_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2021-2022_10m/rgb/2193/collection.json
@@ -2738,6 +2738,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10,
   "created": "2024-03-25T01:05:59Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/new-zealand/new-zealand_2021-2022_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2021-2022_10m/rgb/2193/collection.json
@@ -2740,5 +2740,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 10,
   "created": "2024-03-25T01:05:59Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/new-zealand/new-zealand_2022-2023_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2022-2023_10m/rgb/2193/collection.json
@@ -2740,5 +2740,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 10,
   "created": "2024-02-21T03:59:00Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/new-zealand/new-zealand_2022-2023_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2022-2023_10m/rgb/2193/collection.json
@@ -2738,6 +2738,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10,
   "created": "2024-02-21T03:59:00Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/new-zealand/new-zealand_2023-2024_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2023-2024_10m/rgb/2193/collection.json
@@ -2723,7 +2723,7 @@
   "linz:region": "new-zealand",
   "linz:security_classification": "unclassified",
   "created": "2024-10-02T21:30:07Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "new-zealand_2023-2024_10m",
   "extent": {
     "spatial": { "bbox": [[166.3157485, -47.5345307, 178.6357959, -34.0291036]] },

--- a/stac/new-zealand/new-zealand_2023-2024_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2023-2024_10m/rgb/2193/collection.json
@@ -2739,5 +2739,6 @@
       "file:size": 6107
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10
 }

--- a/stac/new-zealand/new-zealand_2024-2025_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2024-2025_10m/rgb/2193/collection.json
@@ -3078,7 +3078,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "new-zealand_2024-2025_10m",
   "created": "2025-09-19T01:28:04Z",
-  "updated": "2025-09-19T01:28:04Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[166.2762613, -47.5487027, 178.8832065, -34.0291036]] },
     "temporal": { "interval": [["2024-08-31T12:00:00Z", "2025-04-29T12:00:00Z"]] }

--- a/stac/new-zealand/new-zealand_2024-2025_10m/rgb/2193/collection.json
+++ b/stac/new-zealand/new-zealand_2024-2025_10m/rgb/2193/collection.json
@@ -3094,5 +3094,6 @@
       "file:size": 6022
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 10
 }

--- a/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
@@ -1897,5 +1897,6 @@
   },
   "created": "2023-09-09T00:00:00Z",
   "updated": "2026-05-06T03:00:00Z",
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.5
 }

--- a/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
+++ b/stac/new-zealand/north-island_2023_0.5m/rgb/2193/collection.json
@@ -1896,7 +1896,7 @@
     "temporal": { "interval": [["2023-02-20T11:00:00Z", "2023-03-07T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-05-06T03:00:00Z",
+  "updated": "2026-06-25T02:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.5
 }

--- a/stac/northland/northland_2003_0.75m/rgb/2193/collection.json
+++ b/stac/northland/northland_2003_0.75m/rgb/2193/collection.json
@@ -1397,5 +1397,6 @@
   },
   "created": "2023-09-09T00:00:00Z",
   "updated": "2026-05-05T00:00:00Z",
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.75
 }

--- a/stac/northland/northland_2003_0.75m/rgb/2193/collection.json
+++ b/stac/northland/northland_2003_0.75m/rgb/2193/collection.json
@@ -1396,7 +1396,7 @@
     "temporal": { "interval": [["2003-10-02T12:00:00Z", "2003-10-02T12:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-05-05T00:00:00Z",
+  "updated": "2026-06-25T02:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.75
 }

--- a/stac/northland/northland_2004_0.78m/rgb/2193/collection.json
+++ b/stac/northland/northland_2004_0.78m/rgb/2193/collection.json
@@ -1794,5 +1794,6 @@
   },
   "created": "2023-09-09T00:00:00Z",
   "updated": "2026-05-05T00:00:00Z",
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.78
 }

--- a/stac/northland/northland_2004_0.78m/rgb/2193/collection.json
+++ b/stac/northland/northland_2004_0.78m/rgb/2193/collection.json
@@ -1793,7 +1793,7 @@
     "temporal": { "interval": [["2004-03-01T11:00:00Z", "2005-02-02T11:00:00Z"]] }
   },
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2026-05-05T00:00:00Z",
+  "updated": "2026-06-25T02:00:00Z",
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.78
 }

--- a/stac/northland/northland_2023-2024_0.3m/rgb/2193/collection.json
+++ b/stac/northland/northland_2023-2024_0.3m/rgb/2193/collection.json
@@ -11447,7 +11447,7 @@
   "linz:region": "northland",
   "linz:security_classification": "unclassified",
   "created": "2024-07-11T22:38:20Z",
-  "updated": "2025-05-27T01:26:00Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "northland_2023-2024_0.3m",
   "extent": {
     "spatial": { "bbox": [[172.6079116, -36.4324847, 174.8084793, -34.3593284]] },

--- a/stac/northland/northland_2023-2024_0.3m/rgb/2193/collection.json
+++ b/stac/northland/northland_2023-2024_0.3m/rgb/2193/collection.json
@@ -11464,5 +11464,6 @@
       "file:size": 8014
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.3
 }

--- a/stac/otago/otago_2005-2011_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_2005-2011_0.75m/rgb/2193/collection.json
@@ -24186,7 +24186,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "otago_2005-2011_0.75m",
   "created": "2025-08-05T03:15:53Z",
-  "updated": "2025-08-05T03:15:53Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[168.1009665, -46.6590479, 171.1755056, -43.9421577]] },
     "temporal": { "interval": [["2005-02-21T11:00:00Z", "2011-01-23T11:00:00Z"]] }

--- a/stac/otago/otago_2005-2011_0.75m/rgb/2193/collection.json
+++ b/stac/otago/otago_2005-2011_0.75m/rgb/2193/collection.json
@@ -24202,5 +24202,6 @@
       "file:size": 7834
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.75
 }

--- a/stac/otago/otago_2023-2024_0.1m/rgb/2193/collection.json
+++ b/stac/otago/otago_2023-2024_0.1m/rgb/2193/collection.json
@@ -9749,7 +9749,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "created": "2024-08-01T22:43:48Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "otago_2023-2024_0.1m",
   "extent": {
     "spatial": { "bbox": [[169.138494, -45.9774145, 170.7406305, -44.9625898]] },

--- a/stac/otago/otago_2023-2024_0.1m/rgb/2193/collection.json
+++ b/stac/otago/otago_2023-2024_0.1m/rgb/2193/collection.json
@@ -9765,5 +9765,6 @@
       "file:size": 13788
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/otago/otago_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/otago/otago_2023-2024_0.2m/rgb/2193/collection.json
@@ -2957,7 +2957,7 @@
   "linz:region": "otago",
   "linz:security_classification": "unclassified",
   "created": "2024-08-01T03:34:57Z",
-  "updated": "2025-03-11T02:27:37Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "otago_2023-2024_0.2m",
   "extent": {
     "spatial": { "bbox": [[169.7266139, -46.0669944, 170.7781554, -45.2232546]] },

--- a/stac/otago/otago_2023-2024_0.2m/rgb/2193/collection.json
+++ b/stac/otago/otago_2023-2024_0.2m/rgb/2193/collection.json
@@ -2974,5 +2974,6 @@
       "file:size": 3548
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2
 }

--- a/stac/otago/otago_2025_0.2m/rgb/2193/collection.json
+++ b/stac/otago/otago_2025_0.2m/rgb/2193/collection.json
@@ -13024,5 +13024,6 @@
       "file:size": 7448
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.2
 }

--- a/stac/otago/otago_2025_0.2m/rgb/2193/collection.json
+++ b/stac/otago/otago_2025_0.2m/rgb/2193/collection.json
@@ -13008,7 +13008,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "otago_2025_0.2m",
   "created": "2025-04-16T03:55:24Z",
-  "updated": "2025-07-01T22:05:19Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[168.7346833, -46.6590479, 170.4681533, -44.4265284]] },
     "temporal": { "interval": [["2025-01-15T11:00:00Z", "2025-04-24T12:00:00Z"]] }

--- a/stac/southland/southland_2023_0.25m/rgb/2193/collection.json
+++ b/stac/southland/southland_2023_0.25m/rgb/2193/collection.json
@@ -12857,7 +12857,7 @@
   "linz:region": "southland",
   "linz:security_classification": "unclassified",
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "southland_2023_0.25m",
   "extent": {
     "spatial": { "bbox": [[167.2876352, -46.6863264, 169.3028879, -44.6247872]] },

--- a/stac/southland/southland_2023_0.25m/rgb/2193/collection.json
+++ b/stac/southland/southland_2023_0.25m/rgb/2193/collection.json
@@ -12873,5 +12873,6 @@
       "file:size": 6406
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/tasman/tasman-river-valleys-flood_2025_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman-river-valleys-flood_2025_0.1m/rgb/2193/collection.json
@@ -11784,5 +11784,6 @@
       "file:size": 27638
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1
 }

--- a/stac/tasman/tasman-river-valleys-flood_2025_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman-river-valleys-flood_2025_0.1m/rgb/2193/collection.json
@@ -11766,7 +11766,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "tasman-river-valleys-flood_2025_0.1m",
   "created": "2025-07-30T23:54:59Z",
-  "updated": "2025-07-30T23:54:59Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:event_name": "Tasman River Valleys Flood",
   "linz:geographic_description": "Tasman River Valleys Flood",
   "extent": {

--- a/stac/tasman/tasman_2023_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2023_0.075m/rgb/2193/collection.json
@@ -728,6 +728,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075,
   "created": "2024-03-14T08:54:30Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/tasman/tasman_2023_0.075m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2023_0.075m/rgb/2193/collection.json
@@ -730,5 +730,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.075,
   "created": "2024-03-14T08:54:30Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/tasman/tasman_2023_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2023_0.1m/rgb/2193/collection.json
@@ -3866,6 +3866,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1,
   "created": "2024-03-14T08:55:17Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/tasman/tasman_2023_0.1m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2023_0.1m/rgb/2193/collection.json
@@ -3868,5 +3868,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.1,
   "created": "2024-03-14T08:55:17Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/tasman/tasman_2024-2025_0.25m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2024-2025_0.25m/rgb/2193/collection.json
@@ -3906,7 +3906,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "tasman_2024-2025_0.25m",
   "created": "2025-06-17T00:20:32Z",
-  "updated": "2025-06-17T00:20:32Z",
+  "updated": "2026-06-25T02:00:00Z",
   "extent": {
     "spatial": { "bbox": [[172.2024297, -41.627326, 173.3164527, -40.4916196]] },
     "temporal": { "interval": [["2024-12-05T11:00:00Z", "2025-03-26T11:00:00Z"]] }

--- a/stac/tasman/tasman_2024-2025_0.25m/rgb/2193/collection.json
+++ b/stac/tasman/tasman_2024-2025_0.25m/rgb/2193/collection.json
@@ -3922,5 +3922,6 @@
       "file:size": 3882
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/waikato/hamilton_2023-2024_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2023-2024_0.05m/rgb/2193/collection.json
@@ -8861,5 +8861,6 @@
       "file:size": 1998
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05
 }

--- a/stac/waikato/hamilton_2023-2024_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2023-2024_0.05m/rgb/2193/collection.json
@@ -8844,7 +8844,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2023-2024_0.05m",
   "created": "2025-09-12T00:14:16Z",
-  "updated": "2025-09-12T00:14:16Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Hamilton",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },

--- a/stac/waikato/hamilton_2024-2025_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2024-2025_0.05m/rgb/2193/collection.json
@@ -8861,5 +8861,6 @@
       "file:size": 1998
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05
 }

--- a/stac/waikato/hamilton_2024-2025_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/hamilton_2024-2025_0.05m/rgb/2193/collection.json
@@ -8844,7 +8844,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "hamilton_2024-2025_0.05m",
   "created": "2025-09-10T01:53:21Z",
-  "updated": "2025-09-10T01:53:21Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Hamilton",
   "extent": {
     "spatial": { "bbox": [[175.1272909, -37.9068966, 175.3957647, -37.6369305]] },

--- a/stac/waikato/thames-coromandel_2015_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/thames-coromandel_2015_0.05m/rgb/2193/collection.json
@@ -11387,5 +11387,6 @@
       "file:size": 37440
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.05
 }

--- a/stac/waikato/thames-coromandel_2015_0.05m/rgb/2193/collection.json
+++ b/stac/waikato/thames-coromandel_2015_0.05m/rgb/2193/collection.json
@@ -11370,7 +11370,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "thames-coromandel_2015_0.05m",
   "created": "2025-08-06T00:53:29Z",
-  "updated": "2025-08-06T00:53:29Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "Thames-Coromandel",
   "extent": {
     "spatial": { "bbox": [[175.4259311, -37.2364401, 175.8865416, -36.5212753]] },

--- a/stac/waikato/waikato_2021-2023_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2023_0.3m/rgb/2193/collection.json
@@ -22437,5 +22437,6 @@
       "file:size": 9509
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.3
 }

--- a/stac/waikato/waikato_2021-2023_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2021-2023_0.3m/rgb/2193/collection.json
@@ -22421,7 +22421,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "created": "2023-09-09T00:00:00Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "waikato_2021-2023_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.5297583, -39.329461, 176.7120508, -36.3811521]] },

--- a/stac/waikato/waikato_2023-2024_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2023-2024_0.3m/rgb/2193/collection.json
@@ -12563,7 +12563,7 @@
   "linz:region": "waikato",
   "linz:security_classification": "unclassified",
   "created": "2024-07-04T02:18:47Z",
-  "updated": "2024-11-14T01:59:24Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "waikato_2023-2024_0.3m",
   "extent": {
     "spatial": { "bbox": [[174.5731104, -38.8237518, 176.1276692, -36.3811521]] },

--- a/stac/waikato/waikato_2023-2024_0.3m/rgb/2193/collection.json
+++ b/stac/waikato/waikato_2023-2024_0.3m/rgb/2193/collection.json
@@ -12579,5 +12579,6 @@
       "file:size": 7581
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.3
 }

--- a/stac/wellington/porirua_2024_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2024_0.1m/rgb/2193/collection.json
@@ -4043,5 +4043,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.1,
   "created": "2024-04-04T22:56:59Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }

--- a/stac/wellington/porirua_2024_0.1m/rgb/2193/collection.json
+++ b/stac/wellington/porirua_2024_0.1m/rgb/2193/collection.json
@@ -4041,6 +4041,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.1,
   "created": "2024-04-04T22:56:59Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/wellington/south-wairarapa_2025_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/south-wairarapa_2025_0.075m/rgb/2193/collection.json
@@ -4602,7 +4602,7 @@
   "linz:security_classification": "unclassified",
   "linz:slug": "south-wairarapa_2025_0.075m",
   "created": "2025-04-28T02:42:16Z",
-  "updated": "2025-04-28T02:42:16Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:geographic_description": "South Wairarapa",
   "extent": {
     "spatial": { "bbox": [[175.1442312, -41.6052017, 175.5093756, -41.0510807]] },

--- a/stac/wellington/south-wairarapa_2025_0.075m/rgb/2193/collection.json
+++ b/stac/wellington/south-wairarapa_2025_0.075m/rgb/2193/collection.json
@@ -4619,5 +4619,6 @@
       "file:size": 5535
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.075
 }

--- a/stac/wellington/wellington_2024_0.25m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2024_0.25m/rgb/2193/collection.json
@@ -4066,5 +4066,6 @@
       "file:size": 3601
     }
   },
-  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"]
+  "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.25
 }

--- a/stac/wellington/wellington_2024_0.25m/rgb/2193/collection.json
+++ b/stac/wellington/wellington_2024_0.25m/rgb/2193/collection.json
@@ -4049,7 +4049,7 @@
   "linz:region": "wellington",
   "linz:security_classification": "unclassified",
   "created": "2024-06-11T20:43:09Z",
-  "updated": "2025-05-05T02:24:40Z",
+  "updated": "2026-06-25T02:00:00Z",
   "linz:slug": "wellington_2024_0.25m",
   "extent": {
     "spatial": { "bbox": [[175.095257, -41.6383317, 176.3804297, -40.6091576]] },

--- a/stac/west-coast/westport-flood_2021_0.125m/rgb/2193/collection.json
+++ b/stac/west-coast/westport-flood_2021_0.125m/rgb/2193/collection.json
@@ -668,6 +668,7 @@
     }
   },
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
+  "gsd": 0.125,
   "created": "2024-02-29T00:57:59Z",
   "updated": "2024-11-14T01:59:24Z"
 }

--- a/stac/west-coast/westport-flood_2021_0.125m/rgb/2193/collection.json
+++ b/stac/west-coast/westport-flood_2021_0.125m/rgb/2193/collection.json
@@ -670,5 +670,5 @@
   "stac_extensions": ["https://stac-extensions.github.io/file/v2.0.0/schema.json"],
   "gsd": 0.125,
   "created": "2024-02-29T00:57:59Z",
-  "updated": "2024-11-14T01:59:24Z"
+  "updated": "2026-06-25T02:00:00Z"
 }


### PR DESCRIPTION
### Motivation
Some collections had missing gsd. 

### Modifications

A script to add gsd on bulk files has been run. Last fix had introduced unintended formatting, this shouldn't do it. 

