### PR TITLE
feat: Moved Kaikoura earthquake collection to correct location TDE-2009

### DIFF
--- a/stac/canterbury/kaikoura-earthquake_2016-2017_0.3m/rgbnir/2193/collection.json
+++ b/stac/canterbury/kaikoura-earthquake_2016-2017_0.3m/rgbnir/2193/collection.json
@@ -2709,10 +2709,10 @@
   "linz:geospatial_category": "near-infrared-aerial-photos",
   "linz:region": "canterbury",
   "linz:security_classification": "unclassified",
-  "linz:slug": "kaikoura_2016-2017_0.3m",
+  "linz:slug": "kaikoura-earthquake_2016-2017_0.3m",
   "gsd": 0.3,
   "created": "2026-05-03T23:14:12Z",
-  "updated": "2026-07-31T03:39:57Z",
+  "updated": "2026-08-17T23:54:47Z",
   "linz:event_name": "Kaikōura Earthquake",
   "linz:geographic_description": "Kaikōura",
   "extent": {


### PR DESCRIPTION
### Motivation

Kaikoura Earthquake near-infrared dataset published to a different path than its rgb equivalent. It should be moved to the correct location, in the rgbnir folder. 

### Modifications

Moved the associated collection to rgbnir inside the kaikoura-earthquake directory.

